### PR TITLE
DM-10597:  firefly_client upload_data test fails with Python 2

### DIFF
--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -323,7 +323,7 @@ class FireflyClient(WebSocketClient):
                      %(self.this_host, self._basedir))]:
             # quick test of upload url with a small stream
             test = self.session.post(url,
-                                     files={'data': io.StringIO('test')},
+                                     files={'data': io.StringIO(u'test')},
                                      headers=self.headers)
             if test.status_code != 200:
                 continue
@@ -395,7 +395,7 @@ class FireflyClient(WebSocketClient):
                      %(self.this_host, self._basedir))]:
             # quick test of upload url with a small stream
             test = self.session.post(url+'false&type=UNKNOWN',
-                                     files={'data': io.StringIO('test')},
+                                     files={'data': io.StringIO(u'test')},
                                      headers=self.headers)
             if test.status_code != 200:
                 continue

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ from setuptools import setup
 
 setup(
     name='firefly_client',
-    version='1.0.0b4',
+    version='1.0.0',
     description='Python API for Firefly',
     author='IPAC LSST SUIT',
     license='BSD',
     url='http://github.com/Caltech-IPAC/firefly_client',
     packages = ['firefly_client'],
-    install_requires=['ws4py', 'future'],
+    install_requires=['ws4py', 'future', 'requests'],
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Fix a bug in upload_data and upload_file with Python 2, where a unicode string is needed.

- Make the arguments to io.StringIO explicitly Unicode
- Update setup.py to add missing requests module, and set version to 1.0.0