### PR TITLE
DM-10046 Remove deprecated upload URL from firefly_client

### DIFF
--- a/examples/basic-demo.ipynb
+++ b/examples/basic-demo.ipynb
@@ -67,8 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "#host='irsa.ipac.caltech.edu:80'\n",
-    "host='irsawebtest3.ipac.caltech.edu:8080'\n",
+    "host='irsa.ipac.caltech.edu:80'\n",
     "channel = 'myChannel8'\n",
     "basedir = 'irsaviewer'\n",
     "\n",

--- a/examples/basic-demo.ipynb
+++ b/examples/basic-demo.ipynb
@@ -67,7 +67,8 @@
    },
    "outputs": [],
    "source": [
-    "host='irsa.ipac.caltech.edu:80'\n",
+    "#host='irsa.ipac.caltech.edu:80'\n",
+    "host='irsawebtest3.ipac.caltech.edu:8080'\n",
     "channel = 'myChannel8'\n",
     "basedir = 'irsaviewer'\n",
     "\n",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='firefly_client',
-    version='1.0.0',
+    version='1.0.1-dev',
     description='Python API for Firefly',
     author='IPAC LSST SUIT',
     license='BSD',


### PR DESCRIPTION
The development remove the deprecated upload URL (Firefly_FilrUpload) from firefly_client. 

Note: 
the URL root in the demo example is tentatively set to be 'irsawebtest3:8080' and it will be changed back to 'irsa.ipac.caltech.edu:80' after IRSA release (soon in June).