### PR TITLE
DM-11263 Add API function to FireflyClient to control the Firefly blank slate viewer

### DIFF
--- a/examples/firefly_slate_demo.py
+++ b/examples/firefly_slate_demo.py
@@ -1,0 +1,110 @@
+import astropy.utils.data
+
+
+def download_from(url):
+    return astropy.utils.data.download_file(url, timeout=120, cache=True)
+
+
+def load_moving_table(row, col, width, height, fc, cell_id=None):
+    moving_tbl_name = download_from("http://web.ipac.caltech.edu/staff/roby/demo/moving/MOST_results-sample.tbl")
+
+    r = fc.add_cell(row, col, width, height, 'tables', cell_id)
+    meta_info = {'datasetInfoConverterId': 'SimpleMoving',
+                 'positionCoordColumns': 'ra_obj;dec_obj;EQ_J2000',
+                 'datasource': 'image_url'}
+    tbl_name = fc.upload_file(moving_tbl_name)
+
+    if r['success']:
+        fc.show_table(tbl_name, tbl_id='movingtbl', title='A moving object table',
+                      page_size=15, meta=meta_info)
+
+
+def add_simple_m31_image_table(fc):
+    tbl_name = download_from("http://web.ipac.caltech.edu/staff/roby/demo/test-table-m31.tbl")
+
+    meta_info = {'positionCoordColumns': 'ra_obj;dec_obj;EQ_J2000',
+                 'datasource': 'FITS'}
+    fc.show_table(fc.upload_file(tbl_name), title='A table of m31 images', page_size=15, meta=meta_info)
+
+
+def add_simple_image_table(fc):
+    tbl_name = download_from("http://web.ipac.caltech.edu/staff/roby/demo/test-table4.tbl")
+
+    meta_info = {'datasource': 'FITS'}
+    fc.show_table(fc.upload_file(tbl_name), title='A table of simple images', page_size=15, meta=meta_info)
+
+
+def add_table_for_chart(fc):
+    tbl_name = download_from('http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl')
+
+    fc.show_table(fc.upload_file(tbl_name), tbl_id='tbl_chart', title='table for xyplot and histogram', page_size=15)
+
+
+def load_image(row, col, width, height, fc, cell_id=None):
+    r = fc.add_cell(row, col, width, height, 'images', cell_id)
+
+    image_name = download_from('http://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a' +
+                               '/149/02206a149-w1-int-1b.fits?center=70,20&size=200pix')
+
+    if r['success']:
+        fc.show_fits(file_on_server=fc.upload_file(image_name), viewer_id=r['cell_id'], title='WISE Cutout')
+
+
+def load_image_metadata(row, col, width, height, fc, cell_id=None):
+    r = fc.add_cell(row, col, width, height, 'tableImageMeta', cell_id)
+
+    if r['success']:
+        fc.show_image_metadata(viewer_id=r['cell_id'])
+
+
+def load_coverage_image(row, col, width, height, fc, cell_id=None):
+    r = fc.add_cell(row, col, width, height, 'coverageImage', cell_id)
+
+    if r['success']:
+        fc.show_coverage(viewer_id=r['cell_id'])
+
+
+def load_moving(row, col, width, height, fc, cell_id=None):
+    r = fc.add_cell(row, col, width, height, 'images', cell_id)
+
+    if r['success']:
+        v_id = r['cell_id']
+        fc.show_fits(plot_id='m49025b_143_2', viewer_id=v_id,  OverlayPosition='330.347003;-2.774482;EQ_J2000',
+                     ZoomType='TO_WIDTH_HEIGHT', Title='49025b143-w2', plotGroupId='movingGroup',
+                     URL='http://web.ipac.caltech.edu/staff/roby/demo/moving/49025b143-w2-int-1b.fits')
+        fc.show_fits(plot_id='m49273b_134_2', viewer_id=v_id,  OverlayPosition='333.539702;-0.779310;EQ_J2000',
+                     ZoomType='TO_WIDTH_HEIGHT', Title='49273b134-w2', plotGroupId='movingGroup',
+                     URL='http://web.ipac.caltech.edu/staff/roby/demo/moving/49273b134-w2-int-1b.fits')
+        fc.show_fits(plot_id='m49277b_135_1', viewer_id=v_id,  OverlayPosition='333.589054;-0.747251;EQ_J2000',
+                     ZoomType='TO_WIDTH_HEIGHT', Title='49277b135-w1', plotGroupId='movingGroup',
+                     URL='http://web.ipac.caltech.edu/staff/roby/demo/moving/49277b135-w1-int-1b.fits')
+        fc.show_fits(plot_id='m49289b_134_2', viewer_id=v_id,  OverlayPosition='333.736578;-0.651222;EQ_J2000',
+                     ZoomType='TO_WIDTH_HEIGHT', Title='49289b134-w2', plotGroupId='movingGroup',
+                     URL='http://web.ipac.caltech.edu/staff/roby/demo/moving/49289b134-w2-int-1b.fits')
+
+
+def load_xy(row, col, width, height, fc, cell_id=None):
+    r = fc.add_cell(row, col, width, height, 'xyPlots', cell_id)
+
+    if r['success']:
+        fc.show_xyplot('tbl_chart', group_id=r['cell_id'], xCol='ra1', yCol='dec1')
+
+
+def load_histogram(row, col, width, height, fc, cell_id=None):
+    r = fc.add_cell(row, col, width, height, 'xyPlots', cell_id)
+
+    if r['success']:
+        fc.show_histogram('tbl_chart', group_id=r['cell_id'], col='modeint', xOptions='log')
+
+
+def load_first_image_in_random(fc):
+    img_name = download_from('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits')
+
+    fc.show_fits(file_on_server=fc.upload_file(img_name))
+
+
+def load_second_image_in_random(fc):
+    fc.show_fits(plot_id='xxq', Service='TWOMASS', Title='2mass from service', ZoomType='LEVEL',
+                 initZoomLevel=2, SurveyKey='k', WorldPt='10.68479;41.26906;EQ_J2000',
+                 RangeValues='92,-1,92,2,1,0,1,2,44,120', SizeInDeg='.12')
+

--- a/examples/slate-demo-explicit.ipynb
+++ b/examples/slate-demo-explicit.ipynb
@@ -1,0 +1,410 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API for Firefly Slate Viewer to render tables, images and charts in a grid layout style. This notebook shows the same layout content as what ffapi-api-slate.html renders in Firefly. \n",
+    "\n",
+    "Note that it may be necessary to wait for some cells (like those displaying an image) to complete before executing later cells."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for Python 2/3 compatibility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function, division, absolute_import"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for firefly_client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example tentatively uses 127.0.0.1:8080 as the server\n",
+    "\n",
+    "'slate.html' is a template made for grid view "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "host='127.0.0.1:8080'\n",
+    "channel = 'myChannel8'\n",
+    "html = 'slate.html'\n",
+    "\n",
+    "fc = FireflyClient(host, channel=channel, html_file=html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dispaly tables, images, XY charts, and Histograms in Window/Grid like layout\n",
+    "\n",
+    "Each rendered unit on Firefly Slate Viewer is called a'cell'. To render a cell and its content, the cell location (row, column, width, height), element type and cell ID are needed. (row, column) and (width, height) represent the position and size of the cell in terms of the grid blocks on Firefly Slate Viewer. Element types include types of 'tables', images', 'xyPlots', 'tableImageMeta' and 'coverageImage'. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use astropy here for convenience, but firefly_client itself does not depend on astropy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import astropy.utils.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open a browser to the firefly server in a new tab. Only works when running the notebook locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fc.launch_browser()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Display tables and catalogs\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add some tables into cell 'main' (default cell id for tables)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# first table in cell 'main'. \n",
+    "# 'main' is the cell id currently supported by Firefly for element type 'tables'\n",
+    "# this cell is shown at row = 0, col = 0 with width = 4, height = 2\n",
+    "\n",
+    "r = fc.add_cell(0, 0, 4, 2, 'tables', 'main')\n",
+    "\n",
+    "if r['success']:\n",
+    "    tbl_name = astropy.utils.data.download_file(\"http://web.ipac.caltech.edu/staff/roby/demo/moving/MOST_results-sample.tbl\",\n",
+    "                                           timeout=120, cache=True)\n",
+    "    meta_info = {'datasetInfoConverterId': 'SimpleMoving','positionCoordColumns': 'ra_obj;dec_obj;EQ_J2000',\n",
+    "                 'datasource': 'image_url'}\n",
+    "    fc.show_table(tbl_name, tbl_id='movingtbl', title='A moving object table', page_size=15, meta=meta_info)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# add 2nd table in cell 'main' for chart and histogram \n",
+    "\n",
+    "tbl_name = astropy.utils.data.download_file('http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',\n",
+    "                                            timeout=120, cache=True)\n",
+    "fc.show_table(fc.upload_file(tbl_name), tbl_id='tbl_chart', title='table for xyplot and histogram', page_size=15)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# add 3rd table in cell 'main'\n",
+    "\n",
+    "tbl_name = astropy.utils.data.download_file(\"http://web.ipac.caltech.edu/staff/roby/demo/test-table4.tbl\", \n",
+    "                                            timeout=120, cache=True)\n",
+    "meta_info = {'datasource': 'FITS'}\n",
+    "fc.show_table(fc.upload_file(tbl_name), title='A table of simple images', page_size=15, meta=meta_info)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# add 4th table in cell 'main'\n",
+    "\n",
+    "tbl_name = astropy.utils.data.download_file(\"http://web.ipac.caltech.edu/staff/roby/demo/test-table-m31.tbl\", \n",
+    "                                            timeout=120, cache=True)\n",
+    "\n",
+    "meta_info = {'positionCoordColumns': 'ra_obj;dec_obj;EQ_J2000', 'datasource': 'FITS'}\n",
+    "fc.show_table(fc.upload_file(tbl_name), title='A table of m31 images', page_size=15, meta=meta_info)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add different types of image displays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show cell with id 'image-meta' continaing image from the active table containing datasource column in cell 'main'\n",
+    "# the cell is shown at row = 2, col = 0 with width = 4, height = 2 \n",
+    "\n",
+    "r = fc.add_cell(2, 0, 4, 2, 'tableImageMeta', 'image-meta')\n",
+    "if r['success']:\n",
+    "    fc.show_image_metadata(viewer_id=r['cell_id'])\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# show cell 'wise-content' containing fits at row = 0, col = 4 with width = 2, height = 2\n",
+    "\n",
+    "r = fc.add_cell(0, 4, 2, 2, 'images', 'wise-cutout')\n",
+    "if r['success']:\n",
+    "    image_name = astropy.utils.data.download_file('http://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a' +\n",
+    "                                              '/149/02206a149-w1-int-1b.fits?center=70,20&size=200pix')\n",
+    "    fc.show_fits(file_on_server=fc.upload_file(image_name), viewer_id=r['cell_id'], title='WISE Cutout')\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show 4 fits of moving objects in cell 'movingStff' at row = 2, col = 4 with width = 2, height = 2\n",
+    "\n",
+    "r = fc.add_cell(2, 4, 2, 2, 'images', 'movingStuff')\n",
+    "if r['success']:\n",
+    "    v_id = r['cell_id']\n",
+    "    fc.show_fits(plot_id='m49025b_143_2', viewer_id=v_id,  OverlayPosition='330.347003;-2.774482;EQ_J2000',\n",
+    "                 ZoomType='TO_WIDTH_HEIGHT', Title='49025b143-w2', plotGroupId='movingGroup',\n",
+    "                 URL='http://web.ipac.caltech.edu/staff/roby/demo/moving/49025b143-w2-int-1b.fits')\n",
+    "    fc.show_fits(plot_id='m49273b_134_2', viewer_id=v_id,  OverlayPosition='333.539702;-0.779310;EQ_J2000',\n",
+    "                 ZoomType='TO_WIDTH_HEIGHT', Title='49273b134-w2', plotGroupId='movingGroup',\n",
+    "                 URL='http://web.ipac.caltech.edu/staff/roby/demo/moving/49273b134-w2-int-1b.fits')\n",
+    "    fc.show_fits(plot_id='m49277b_135_1', viewer_id=v_id,  OverlayPosition='333.589054;-0.747251;EQ_J2000',\n",
+    "                 ZoomType='TO_WIDTH_HEIGHT', Title='49277b135-w1', plotGroupId='movingGroup',\n",
+    "                 URL='http://web.ipac.caltech.edu/staff/roby/demo/moving/49277b135-w1-int-1b.fits')\n",
+    "    fc.show_fits(plot_id='m49289b_134_2', viewer_id=v_id,  OverlayPosition='333.736578;-0.651222;EQ_J2000',\n",
+    "                 ZoomType='TO_WIDTH_HEIGHT', Title='49289b134-w2', plotGroupId='movingGroup',\n",
+    "                 URL='http://web.ipac.caltech.edu/staff/roby/demo/moving/49289b134-w2-int-1b.fits')\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add charts (xy plot and histogram)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show the cell 'chart-cell-xy' with xy plot related to the table with id 'tbl_chart' in cell 'main'\n",
+    "# this cell is shown at row = 4, col = 0 with width = 2, height = 3\n",
+    "\n",
+    "r = fc.add_cell(4, 0, 2, 3, 'xyPlots', 'chart-cell-xy')\n",
+    "if r['success']:\n",
+    "    fc.show_xyplot('tbl_chart', group_id=r['cell_id'], xCol='ra1', yCol='dec1')\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# show the cell with histogram related to the table with id 'tbl_chart' in cell 'main', \n",
+    "# this cell is shown at row = 4, col = 2, with width = 2, height = 3 \n",
+    "# the cell id is automatically created by FireflyClient in case it is not specified externally. \n",
+    "\n",
+    "r = fc.add_cell(4, 2, 2, 3, 'xyPlots')\n",
+    "if r['success']:\n",
+    "    fc.show_histogram('tbl_chart', group_id=r['cell_id'], col='modeint', xOptions='log')\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add more images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# show coverage image associated with the active table in cell 'main'\n",
+    "# ths cell is shown at row = 4, col = 4 with width = 3, height = 3\n",
+    "\n",
+    "r = fc.add_cell(4, 4, 3, 3, 'coverageImage', 'image-coverage')\n",
+    "if r['success']:\n",
+    "    fc.show_coverage(viewer_id=r['cell_id'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# show image in random location without passing cell location and cell id (i.e. without calling add_cell)\n",
+    "# the image is shown in the cell with id 'DEFAULT_FITS_VIEWER_ID' in default, \n",
+    "# and the cell is automatically located by Firefly\n",
+    "\n",
+    "img_name = astropy.utils.data.download_file('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits', \n",
+    "                                            timeout=120, cache=True)\n",
+    "fc.show_fits(file_on_server=fc.upload_file(img_name))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# show second image in random. it is shown in the same cell as the previous one  \n",
+    "\n",
+    "fc.show_fits(plot_id='xxq', Service='TWOMASS', Title='2mass from service', ZoomType='LEVEL',\n",
+    "             initZoomLevel=2, SurveyKey='k', WorldPt='10.68479;41.26906;EQ_J2000',\n",
+    "             RangeValues='92,-1,92,2,1,0,1,2,44,120', SizeInDeg='.12')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/slate-demo.ipynb
+++ b/examples/slate-demo.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API for Firefly Slate Viewer.\n",
+    "\n",
+    "Note that it may be necessary to wait for some cells (like those displaying an image) to complete before executing later cells."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for Python 2/3 compatibility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function, division, absolute_import"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for firefly_client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import firefly_slate_demo as fs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example tentatively uses localhost:8080 as the server\n",
+    "\n",
+    "'slate.html' is a template made for grid view "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "host='localhost:8080'\n",
+    "channel = 'myChannel8'\n",
+    "html = 'slate.html'\n",
+    "\n",
+    "fc = FireflyClient(host, channel=channel, html_file=html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dispaly tables, images, XY charts, and Histograms in Window/Grid like layout\n",
+    "\n",
+    "Each rendering unit on Firefly Slate Viewer is called a'cell'. To render a cell and its content, the cell location (row, column, width, height) and a cell ID are needed.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use astropy here for convenience, but firefly_client itself does not depend on astropy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import astropy.utils.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please refer to firefly_slate_demo.py to get functions which are made to render cells with the elements which could be tables, images, xy charts or histograms onto Firefly Slate Viewer. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display tables and catalogs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open a browser to the firefly server in a new tab. Only works when running the notebook locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fc.launch_browser()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add some tables into cell 'main' (default grid viewer id for tables)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# first table in cell 'main' \n",
+    "fs.load_moving_table(0,0,4,2, fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# table in cell 'main' for chart and histogram \n",
+    "fs.add_table_for_chart(fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# table in cell 'main'\n",
+    "fs.add_simple_image_table(fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# table in cell 'main'\n",
+    "fs.add_simple_m31_image_table(fc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add different types of image displays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show image from image metadata table associated with the active table in cell 'main'\n",
+    "fs.load_image_metadata(2, 0, 4, 2, fc, 'image-meta')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show an fits in cell 'wise-cutout'\n",
+    "fs.load_image(0, 4, 2, 2, fc, 'wise-cutout')             # load an image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show 4 fits of moving objects in cell 'movingStff'\n",
+    "fs.load_moving(2, 4, 2, 2, fc, 'movingStuff')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add charts (xy plot and histogram)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show xy plot in cell 'chart-cell-xy' associated with the table for chart in cell 'main'\n",
+    "fs.load_xy(4, 0, 2, 3, fc, 'chart-cell-xy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show histogram associated with the table for chart in cell 'main', the cell id is generated by firefly_client\n",
+    "fs.load_histogram(4, 2, 2, 3, fc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add more images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show coverage image associated with the active table in cell 'main'\n",
+    "fs.load_coverage_image(4, 4, 3, 3, fc, 'image-coverage')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show image in randon location without passing the location and cell id\n",
+    "fs.load_first_image_in_random(fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# show second image in random. it will locate in the same cell as the previous one  \n",
+    "fs.load_second_image_in_random(fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/slate-demo.ipynb
+++ b/examples/slate-demo.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates basic usage of the firefly_client API for Firefly Slate Viewer.\n",
+    "This notebook demonstrates basic usage of the firefly_client API for Firefly Slate Viewer to render tables, images and charts in a grid layout style. This notebook shows the same layout content as what ffapi-api-slate.html renders in Firefly.\n",
     "\n",
     "Note that it may be necessary to wait for some cells (like those displaying an image) to complete before executing later cells."
    ]
@@ -54,21 +54,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "import firefly_slate_demo as fs"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example tentatively uses localhost:8080 as the server\n",
+    "This example tentatively uses 127.0.0.1:8080 as the server\n",
     "\n",
     "'slate.html' is a template made for grid view "
    ]
@@ -81,7 +70,7 @@
    },
    "outputs": [],
    "source": [
-    "host='localhost:8080'\n",
+    "host='127.0.0.1:8080'\n",
     "channel = 'myChannel8'\n",
     "html = 'slate.html'\n",
     "\n",
@@ -94,14 +83,14 @@
    "source": [
     "## Dispaly tables, images, XY charts, and Histograms in Window/Grid like layout\n",
     "\n",
-    "Each rendering unit on Firefly Slate Viewer is called a'cell'. To render a cell and its content, the cell location (row, column, width, height) and a cell ID are needed.  "
+    "Each rendered unit on Firefly Slate Viewer is called a'cell'. To render a cell and its content, the cell location (row, column, width, height), element type and cell ID are needed. (row, column) and (width, height) represent the position and size of the cell in terms of the grid blocks on Firefly Slate Viewer. Element types include types of 'tables', images', 'xyPlots', 'tableImageMeta' and 'coverageImage'.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use astropy here for convenience, but firefly_client itself does not depend on astropy."
+    "Please refer to firefly_slate_demo.py which contains functions to render cells with element tables, images, xy charts or histograms onto Firefly Slate Viewer by using firefly_client API. "
    ]
   },
   {
@@ -112,14 +101,7 @@
    },
    "outputs": [],
    "source": [
-    "import astropy.utils.data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Please refer to firefly_slate_demo.py to get functions which are made to render cells with the elements which could be tables, images, xy charts or histograms onto Firefly Slate Viewer. "
+    "import firefly_slate_demo as fs"
    ]
   },
   {
@@ -174,7 +156,7 @@
    },
    "outputs": [],
    "source": [
-    "# table in cell 'main' for chart and histogram \n",
+    "# add table in cell 'main' for chart and histogram \n",
     "fs.add_table_for_chart(fc)"
    ]
   },
@@ -186,7 +168,7 @@
    },
    "outputs": [],
    "source": [
-    "# table in cell 'main'\n",
+    "# add table in cell 'main'\n",
     "fs.add_simple_image_table(fc)"
    ]
   },
@@ -198,7 +180,7 @@
    },
    "outputs": [],
    "source": [
-    "# table in cell 'main'\n",
+    "# add table in cell 'main'\n",
     "fs.add_simple_m31_image_table(fc)"
    ]
   },
@@ -217,7 +199,7 @@
    },
    "outputs": [],
    "source": [
-    "# show image from image metadata table associated with the active table in cell 'main'\n",
+    "# show cell containing the image from the active table with datasource column in cell 'main'\n",
     "fs.load_image_metadata(2, 0, 4, 2, fc, 'image-meta')"
    ]
   },
@@ -229,7 +211,7 @@
    },
    "outputs": [],
    "source": [
-    "# show an fits in cell 'wise-cutout'\n",
+    "# show cell containing FITS in cell 'wise-cutout'\n",
     "fs.load_image(0, 4, 2, 2, fc, 'wise-cutout')             # load an image"
    ]
   },
@@ -241,7 +223,7 @@
    },
    "outputs": [],
    "source": [
-    "# show 4 fits of moving objects in cell 'movingStff'\n",
+    "# show cell with 4 FITS of moving objects in cell 'movingStff'\n",
     "fs.load_moving(2, 4, 2, 2, fc, 'movingStuff')"
    ]
   },
@@ -291,7 +273,7 @@
    },
    "outputs": [],
    "source": [
-    "# show coverage image associated with the active table in cell 'main'\n",
+    "# show cell containing coverage image associated with the active table in cell 'main'\n",
     "fs.load_coverage_image(4, 4, 3, 3, fc, 'image-coverage')"
    ]
   },
@@ -303,7 +285,7 @@
    },
    "outputs": [],
    "source": [
-    "# show image in randon location without passing the location and cell id\n",
+    "# show cell containing image in ranmon location without passing the location and cell id\n",
     "fs.load_first_image_in_random(fc)"
    ]
   },
@@ -315,7 +297,7 @@
    },
    "outputs": [],
    "source": [
-    "# show second image in random. it will locate in the same cell as the previous one  \n",
+    "# show second image in random location. This image is located in the same cell as the previous one  \n",
     "fs.load_second_image_in_random(fc)"
    ]
   },

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -762,8 +762,6 @@ class FireflyClient(WebSocketClient):
                 comma separated list of x axis options: flip,log.
             **yOptions**: `str`
                 comma separated list of y axis options: flip,log.
-            **fixedBinSizeSelection**: {'binWidth', 'numBins'}
-                Fixed bin size selection.
             **falsePositiveRate**: `int` or `float`
                 false positive rate for bayesian blocks algorithm.
             **numBins** : `int`
@@ -780,19 +778,23 @@ class FireflyClient(WebSocketClient):
         """
 
         chart_data_elements = {'type': 'histogram', 'tblId': tbl_id}
+
         if 'col' in histogram_params:
             options = {'columnOrExpr': histogram_params.get('col'),
                        'x': histogram_params.get('xOptions', ''),
                        'y': histogram_params.get('yOptions', '')}
 
-            if 'false_positive_rate' in histogram_params and 'numBins' not in histogram_params:
-                options.update({'falsePositiveRate': histogram_params.get('false_positive_rate')})
+            if 'falsePositiveRate' in histogram_params:
+                options.update({'falsePositiveRate': histogram_params.get('falsePositiveRate')})
                 options.update({'algorithm': 'bayesianBlocks'})
             else:
-                options.update({'fixedBinSizeSelection': histogram_params.get('fixedBinSizeSelection', 'numBins'),
-                                'numBins': histogram_params.get('numBins', 50),
-                                'binWidth': histogram_params.get('binWidth', 0),
-                                'algorithm': 'fixedSizeBins'})
+                options.update({'algorithm': 'fixedSizeBins'})
+                if 'numBins' in histogram_params or histogram_params.get('binWidth', 0) == 0:
+                    options.update({'fixedBinSizeSelection': histogram_params.get('fixedBinSizeSelection', 'numBins'),
+                                    'numBins': histogram_params.get('numBins', 50)})
+                else:
+                    options.update({'fixedBinSizeSelection': histogram_params.get('fixedBinSizeSelection', 'binWidth'),
+                                    'binWidth': histogram_params.get('binWidth')})
             chart_data_elements.update({'options': options})
 
         if not group_id:

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -52,8 +52,15 @@ class FireflyClient(WebSocketClient):
     EXTENSION_TYPE = ['AREA_SELECT', 'LINE_SELECT', 'POINT']
     """Type of plot where the extension is added to (`list` of `str`)."""
 
+    # layout view type
+    LO_VIEW_DICT = {'table': 'tables',
+                    'image': 'images',
+                    'xyPlot': 'xyPlots',
+                    'imageMeta': 'tableImageMeta',
+                    'coverImage': 'coverageImage'}
+    """Definition of layout viewer (`dict`)."""
 
-    # actions from Firefly
+    # actions from Firefly/
     ACTION_DICT = {
         'ShowFits': 'ImagePlotCntlr.PlotImage',
         'AddExtension': 'ExternalAccessCntlr/extensionAdd',
@@ -68,11 +75,15 @@ class FireflyClient(WebSocketClient):
         'AddRegionData': 'DrawLayerCntlr.RegionPlot.addRegion',
         'RemoveRegionData': 'DrawLayerCntlr.RegionPlot.removeRegion',
         'PlotMask': 'ImagePlotCntlr.plotMask',
-        'DeleteOverlayMask': 'ImagePlotCntlr.deleteOverlayPlot'}
+        'DeleteOverlayMask': 'ImagePlotCntlr.deleteOverlayPlot',
+        'AddCell': 'layout.addCell',
+        'ShowCoverage': 'layout.enableSpecialViewer',
+        'ShowImageMetaData': 'layout.enableSpecialViewer'}
     """Definition of Firefly action (`dict`)."""
 
     # id for table, region layer, extension
-    _item_id = {'Table': 0, 'RegionLayer': 0, 'Extension': 0, 'MaskLayer': 0, 'XYPlot': 0}
+    _item_id = {'Table': 0, 'RegionLayer': 0, 'Extension': 0, 'MaskLayer': 0, 'XYPlot': 0,
+                'Cell': 0, 'Histogram': 0}
 
     # urls:
     # launch browser:  http://<host>/<basedir>/;wsch=<channel id> or (mode == 'full')
@@ -81,7 +92,7 @@ class FireflyClient(WebSocketClient):
     #                  &cmd=pushAction&Action=<ACTION_DICT>
     # open websocket:  ws://<host>/<basedir>/sticky/firefly/events?channdleID=<channel id>
 
-    def __init__(self, host=_my_localhost, channel=None, basedir='firefly'):
+    def __init__(self, host=_my_localhost, channel=None, basedir='firefly', html_file=None):
         self._basedir = basedir
         self._fftools_cmd = '/%s/sticky/CmdSrv' % self._basedir
         if host.startswith('http://'):
@@ -95,11 +106,13 @@ class FireflyClient(WebSocketClient):
         WebSocketClient.__init__(self, url)
 
         self.url_root = 'http://' + host + self._fftools_cmd
-        self.url_bw = 'http://' + self.this_host + '/%s;wsch=' % self._basedir
+        self.html_file = ('/'+html_file) if html_file else ''
+        self.url_bw = 'http://' + self.this_host + '/%s%s;wsch=' % (self._basedir, self.html_file)
 
         self.listeners = {}
         self.channel = channel
         self.session = requests.Session()
+        self.headers = {'FF_FF-channel': self.channel}
         # print 'websocket url:%s' % url
         self.connect()
 
@@ -248,9 +261,10 @@ class FireflyClient(WebSocketClient):
         if not channel:
             channel = self.channel
 
-        url = 'http://%s/%s?id=Loader&channelID='%(self.this_host,self._basedir)
+        url = 'http://%s/%s%s?id=Loader&channelID='%(self.this_host, self._basedir, self.html_file)
         if mode.lower() == "full":
             url = self.url_bw
+
         return url + channel
 
     def launch_browser(self, url=None, channel=None, force=False):
@@ -280,6 +294,7 @@ class FireflyClient(WebSocketClient):
         if not url:
             url = self.url_bw
         do_open = True if force else not self._is_page_connected()
+
         if do_open:
             webbrowser.open(self.get_firefly_url(url, channel))
 
@@ -468,10 +483,55 @@ class FireflyClient(WebSocketClient):
     # -------------------------
 
     # --------------------------------------------------------------------------
-    # action on showing fits, tables, XYPlot, adding extension, and adding mask
+    # action on adding cell for slate viewer,
+    #           showing fits, tables, XYPlot, adding extension, and adding mask
     # -------------------------------------------------------------------------
 
-    def show_fits(self, file_on_server=None, plot_id=None, **additional_params):
+    def add_cell(self, row, col, width, height, element_type, cell_id=None):
+        """
+        Add a slate viewer cell.
+
+        Parameters
+        ----------
+        row : `int`
+            Cell row position.
+        col : `int`
+            Cell column position.
+        width : `int`
+            Cell horizontal size.
+        height : `int`
+            Cell vertical size.
+        element_type : {'tables', 'images', 'xyPlots', 'tableImageMeta', 'coverageImage'}
+            Cell element type. Use 'xyPlots' for histograms.
+        cell_id : `str`, optional
+            Cell Id.
+
+        Returns
+        -------
+        out : `dict`
+            Status of the request, like {'success': True, 'cell_id': 'Cell-1'}.
+        """
+
+        # force the cell_id to be 'main' for table's case
+        if element_type == FireflyClient.LO_VIEW_DICT['table']:
+            if not cell_id or cell_id != 'main':
+                cell_id = 'main'
+        else:
+            if not cell_id:
+                cell_id = FireflyClient._gen_item_id('Cell')
+
+        payload = {'row': row,
+                   'col': col,
+                   'width': width,
+                   'height': height,
+                   'type': element_type,
+                   'cellId': cell_id}
+
+        r = self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['AddCell'], payload)
+        r.update({'cell_id': cell_id})
+        return r
+
+    def show_fits(self, file_on_server=None, plot_id=None, viewer_id=None, **additional_params):
         """
         Show a FITS image.
 
@@ -483,6 +543,9 @@ class FireflyClient(WebSocketClient):
             Firefly has direct access to.
         plot_id : `str` or `list` of `str`, optional
             The ID you assign to the image plot. This is necessary to further control the plot.
+        viewer_id : `str`, optional
+            The ID you assign to the viewer (or cell) used to contain the image plot. If grid view is used for
+            display, the viewer id is the cell id of the cell which contains the image plot.
 
         \*\*additional_params : optional keyword arguments
             Any valid fits viewer plotting parameters, please see the details in `fits plotting parameters`_.
@@ -505,17 +568,23 @@ class FireflyClient(WebSocketClient):
         wp_request = {'plotGroupId': 'groupFromPython',
                       'GroupLocked': False}
         payload = {'wpRequest': wp_request,
-                   'useContextModifications': True,
-                   'viewerId': 'DEFAULT_FITS_VIEWER_ID'}
+                   'useContextModifications': True}
+
+        if not viewer_id:
+            viewer_id = 'DEFAULT_FITS_VIEWER_ID'
+
+        payload.update({'viewerId': viewer_id})
         if plot_id:
             payload['wpRequest'].update({'plotId': plot_id})
         if file_on_server:
             payload['wpRequest'].update({'file': file_on_server})
         if additional_params:
             payload['wpRequest'].update(additional_params)
+
         return self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['ShowFits'], payload)
 
-    def show_table(self, file_on_server, tbl_id=None, title=None, page_size=100, is_catalog=True):
+    def show_table(self, file_on_server, tbl_id=None, title=None, page_size=100, is_catalog=True,
+                   meta=None):
         """
         Show a table.
 
@@ -533,6 +602,8 @@ class FireflyClient(WebSocketClient):
             The number of rows that are shown in the table page (the default is 100).
         is_catalog : `bool`, optional
             If the table file is a catalog (the default is *True*) or not.
+        meta : `dict`
+            META_INFO for the table search request.
 
         Returns
         -------
@@ -544,11 +615,14 @@ class FireflyClient(WebSocketClient):
             tbl_id = FireflyClient._gen_item_id('Table')
         if not title:
             title = tbl_id
-        tbl_type = 'table' if not is_catalog else 'catalog'
 
+        meta_info = {'title': title, 'tbl_id': tbl_id}
+        if meta:
+            meta_info.update(meta)
+
+        tbl_type = 'table' if not is_catalog else 'catalog'
         tbl_req = {'startIdx': 0, 'pageSize': page_size, 'source': file_on_server, 'tblType': tbl_type,
                    'id': 'IpacTableFromSource', 'tbl_id': tbl_id}
-        meta_info = {'title': title, 'tbl_id': tbl_id}
         tbl_req.update({'META_INFO': meta_info})
         payload = {'request': tbl_req}
 
@@ -584,8 +658,7 @@ class FireflyClient(WebSocketClient):
         payload = {'request': tbl_req, 'hlRowIdx': 0}
         return self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['FetchTblData'], payload)
 
-
-    def show_xyplot(self, tbl_id, standalone=False, **chart_params):
+    def show_xyplot(self, tbl_id, standalone=False, group_id=None, **chart_params):
         """
         Show a XY plot
 
@@ -595,7 +668,10 @@ class FireflyClient(WebSocketClient):
             A table ID of the data to be plotted.
         standalone : `bool`, optional
             When it is *True*, the chart is always present in the chart area,
-            no matter if the related table is present or not
+            no matter if the related table is present or not.
+        group_id : `str`, optional
+            Group ID of the chart group where the chart belongs to. If grid view is used, group id is
+            the cell id of the cell which contains the chart.
         \*\*chart_params : optional keyword arguments
             Parameters for XY Plot. The options are shown as below:
 
@@ -608,7 +684,7 @@ class FireflyClient(WebSocketClient):
                 Column or expression to use for y values, can contain multiple column names,
                 ex. *sin(col)* or *(col1-col2)/col3*.
             **yError**: `str`
-                Column or expression to use for x error, can contain multiple column names
+                Column or expression to use for x error, can contain multiple column names.
             **xyRatio** : `int` or  `float`
                 Aspect ratio (must be between 1 and 10).
             **stretch** : {'fit', 'fill'}
@@ -653,15 +729,129 @@ class FireflyClient(WebSocketClient):
         chart_data_elements = [{'type': 'xycols', 'options': options, 'tblId': tbl_id}]
 
         cid = FireflyClient._gen_item_id('XYPlot')
-        if standalone:
-            group_id = 'default'
-        else:
-            group_id = tbl_id
+
+        if not group_id:
+            if standalone:
+                group_id = 'default'
+            else:
+                group_id = tbl_id
 
         payload = {'chartId': cid, 'chartType': 'scatter', 'groupId': group_id,
                    'chartDataElements': chart_data_elements}
 
         return self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['ShowXYPlot'], payload)
+
+    def show_histogram(self, tbl_id, group_id=None, **histogram_params):
+        """
+        Show a histogram
+
+        Parameters
+        ----------
+        tbl_id : `str`
+            A table ID of the data to be plotted.
+        group_id : `str`, optional
+            Group ID of the chart group where the histogram belongs to. If grid view is used, group id is the
+            cell id of the cell which contains the histogram.
+        \*\*histogram_params : optional keyword arguments
+            Parameters for histogram. The options are shown as below:
+
+            **col**: `str`
+                Column or expression to use for x values, can contain multiple column names,
+                ex. *log(col)* or *(col1-col2)/col3*.
+            **xOptions**: `str`
+                comma separated list of x axis options: flip,log.
+            **yOptions**: `str`
+                comma separated list of y axis options: flip,log.
+            **fixedBinSizeSelection**: {'binWidth', 'numBins'}
+                Fixed bin size selection.
+            **falsePositiveRate**: `int` or `float`
+                false positive rate for bayesian blocks algorithm.
+            **numBins** : `int`
+                Number of bins for fixed bins algorithm, default is 50.
+            **binWidth** : `int` or `float`
+                Bin width.
+
+        Returns
+        -------
+        out : `dict`
+            Status of the request, like {'success': True}.
+
+        .. note:: For the histogram parameters, `col` is required.
+        """
+
+        chart_data_elements = {'type': 'histogram', 'tblId': tbl_id}
+        if 'col' in histogram_params:
+            options = {'columnOrExpr': histogram_params.get('col'),
+                       'x': histogram_params.get('xOptions', ''),
+                       'y': histogram_params.get('yOptions', '')}
+
+            if 'false_positive_rate' in histogram_params and 'numBins' not in histogram_params:
+                options.update({'falsePositiveRate': histogram_params.get('false_positive_rate')})
+                options.update({'algorithm': 'bayesianBlocks'})
+            else:
+                options.update({'fixedBinSizeSelection': histogram_params.get('fixedBinSizeSelection', 'numBins'),
+                                'numBins': histogram_params.get('numBins', 50),
+                                'binWidth': histogram_params.get('binWidth', 0),
+                                'algorithm': 'fixedSizeBins'})
+            chart_data_elements.update({'options': options})
+
+        if not group_id:
+            group_id = 'default'
+
+        cid = FireflyClient._gen_item_id('Histogram')
+        payload = {'chartId': cid, 'chartType': 'histogram',
+                   'groupId': group_id,
+                   'chartDataElements': [chart_data_elements]}
+
+        return self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['ShowXYPlot'], payload)
+
+    def show_coverage(self, viewer_id=None, table_group='main'):
+        """
+        Show image coverage associated with the active table in the specified table group
+
+        Parameters
+        ----------
+        viewer_id : `str`, optional
+            Viewer id, the cell id of the cell which contains the coverage image.
+        table_group : `str`, optional
+            Table group which the image coverage associated table belongs to.
+
+        Returns
+        -------
+        out : `dict`
+            Status of the request, like {'success': True}
+        """
+
+        view_type = 'coverImage'
+        cid = viewer_id if viewer_id else ("%s-%s" % (FireflyClient.LO_VIEW_DICT[view_type], table_group))
+        payload = {'viewerType': FireflyClient.LO_VIEW_DICT[view_type],
+                   'cellId': cid}
+
+        return self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['ShowCoverage'], payload)
+
+    def show_image_metadata(self, viewer_id=None, table_group='main'):
+        """
+        Show the image associated with the active (image metadata) table in the specified table group
+
+        Parameters
+        ----------
+        viewer_id : `str`, optional
+            Viewer id, the cell id of the cell which contains the image from image metadata table.
+        table_group : `str`, optional
+            Table group which the image metadata table belongs to.
+
+        Returns
+        -------
+        out : `dict`
+            Status of the request, like {'success': True}
+        """
+
+        view_type = 'imageMeta'
+        cid = viewer_id if viewer_id else ("%s-%s" % (FireflyClient.LO_VIEW_DICT[view_type], table_group))
+        payload = {'viewerType': FireflyClient.LO_VIEW_DICT[view_type],
+                   'cellId': cid}
+
+        return self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['ShowImageMetaData'], payload)
 
     def add_extension(self, ext_type, plot_id=None, title='', tool_tip='',
                       extension_id=None, image_src=None):
@@ -1104,7 +1294,7 @@ class FireflyClient(WebSocketClient):
 
         Parameters
         ----------
-        item : {'Table', 'RegionLayer', 'Extension', 'XYPlot'}
+        item : {'Table', 'RegionLayer', 'Extension', 'XYPlot', 'Cell'}
             Entity type.
 
         Returns
@@ -1118,3 +1308,4 @@ class FireflyClient(WebSocketClient):
             return item + '-' + str(cls._item_id[item])
         else:
             return None
+


### PR DESCRIPTION
The development includes, 
- Add API to FireflyClient to dispatch the same actions as Javascript does to control the Firefly blank slate viewer,  
  . add_cell
  . show_coverage
  . show_image_metadata
  
- add show_histogram to show the histogram in addition to show_xyPlot
- update show_fits, show_table, show_xyPlot and FireflyClient init functions to accommodate the use of Firefly slate viewer.
- create a new Jupyter Notebook page, firefly_slate_demo, to demonstrate the binding similar to what ffpai-state-test.html does in Javascript for Firefly blank slate viewer demo.

Test:
open firefly_slate_demo from Jupyter Notebook, and run the codes to see the rendering of the cells with tables, image and charts on the slate viewer. 
