### PR TITLE
DM-13768 post-review fixes for headers, making https:// work

### DIFF
--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -15,6 +15,7 @@ import json
 import time
 import socket
 import urllib.parse
+import uuid
 import math
 import mimetypes
 import base64
@@ -110,8 +111,10 @@ class FireflyClient(WebSocketClient):
         self.this_host = host
 
         url = '%s://%s/%s/sticky/firefly/events' % (wsproto, host, self._basedir)  # web socket url
-        if channel:
-            url += '?channelID=%s' % channel
+        if channel is None:
+            channel = str(uuid.uuid1())
+
+        url += '?channelID=%s' % channel
         WebSocketClient.__init__(self, url)
 
         self.url_root = protocol + '://' + host + self._fftools_cmd
@@ -119,6 +122,7 @@ class FireflyClient(WebSocketClient):
         self.url_bw = protocol + '://' + self.this_host + '/%s%s?__wsch=' % (self._basedir, self.html_file)
         self.listeners = {}
         self.channel = channel
+        self.headers = {'FF-channel':channel}
         self.session = requests.Session()
         self.connect()
 
@@ -264,7 +268,7 @@ class FireflyClient(WebSocketClient):
         out : `str`
             url string.
         """
-        if not channel:
+        if channel is None:
             channel = self.channel
 
         url = self.url_bw

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='firefly_client',
-    version='1.2.1',
+    version='1.2.2',
     description='Python API for Firefly',
     author='IPAC LSST SUIT',
     license='BSD',


### PR DESCRIPTION
**This is a preliminary pull request, not yet ready for final review**

Handle some issues with headers that came up when testing the `display_firefly` part of DM-13768.

* bump bug fix version to 1.2.2
* populate headers in FireflyClient