### PR TITLE
DM-12973 Add functions to support HiPS display

### DIFF
--- a/examples/slate_hips_test.ipynb
+++ b/examples/slate_hips_test.ipynb
@@ -1,0 +1,305 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API.\n",
+    "\n",
+    "Note that it may be necessary to wait for some cells (like those displaying an image) to complete before executing later cells."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for Python 2/3 compatibility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function, division, absolute_import\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for firefly_client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target='148.892;69.0654;EQ_J2000'\n",
+    "fov_deg=0.5\n",
+    "size=0.2\n",
+    "\n",
+    "image_basic_req = {\n",
+    "    'Service': 'WISE',\n",
+    "    'Title': 'Wise',\n",
+    "    'SurveyKey': '3a',\n",
+    "    'SurveyKeyBand': '2'\n",
+    "}\n",
+    "\n",
+    "hips_basic_req = {\n",
+    "    'title': 'A HiPS - 0.2',\n",
+    "    'hipsRootUrl': 'http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example we use the slate.html application for the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "host='127.0.0.1:8080'\n",
+    "channel = 'myChannel8'\n",
+    "html = 'slate.html'\n",
+    "\n",
+    "fc = FireflyClient(host, channel=channel, html_file=html)\n",
+    "fc.launch_browser()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc.reinit_viewer()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show HiPS "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A HiPS is displayed based on HiPS url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_id = 'hipsDIV1'\n",
+    "r = fc.add_cell(0, 0, 4, 2, 'images', viewer_id)\n",
+    "if r['success']:\n",
+    "    hips_url = 'http://alasky.u-strasbg.fr/DSS/DSSColor';\n",
+    "    status = fc.show_hips(viewer_id=viewer_id, plot_id='aHipsID1-1', hips_root_url = hips_url, \n",
+    "                          Title='HiPS-DSS', WorldPt=target)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show another HiPS in the same viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if r['success']:\n",
+    "    hips_url = 'http://alasky.u-strasbg.fr/DSS/DSS2Merged';\n",
+    "    status = fc.show_hips(viewer_id=viewer_id, plot_id='aHipsID1-2', hips_root_url = hips_url, \n",
+    "                          Title='HiPS-DSS2', WorldPt=target)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show HiP with hips to image conversion info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hiconversion = {\n",
+    "    'imageRequestRoot': dict(hips_basic_req),\n",
+    "    'fovDegFallOver': fov_deg\n",
+    "}\n",
+    "\n",
+    "viewer_id = 'hipsDiv2'\n",
+    "r = fc.add_cell(0, 4, 2, 2, 'images', viewer_id)\n",
+    "if r['success']:\n",
+    "    hips_url = 'http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1'\n",
+    "    status = fc.show_hips(viewer_id=viewer_id, plot_id='aHipsID2', hips_root_url=hips_url, \n",
+    "                          hips_image_conversion=hiconversion)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show Image or HiPS\n",
+    "\n",
+    "Either HiPS or image is displayed per info, such as size or target, defined in image_request, hips_request or allsky_request. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HiPS is displayed => hips_requst: {size:no, target:no}, image_request: {size:no, target:yes} "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_id = 'hipsDiv3'\n",
+    "r = fc.add_cell(2, 0, 2, 2, 'images', viewer_id)\n",
+    "if r['success']:\n",
+    "    status = fc.show_image_or_hips(viewer_id=viewer_id, image_request=dict(image_basic_req),\n",
+    "                                   hips_request=dict(hips_basic_req), fov_deg_fallover=fov_deg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HiPS is displayed => hips_request: {size:no, target:no}, image_request: {target:yes, size:no} "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_id = 'hipsDiv4'\n",
+    "r = fc.add_cell(2, 2, 2, 2, 'images', viewer_id)\n",
+    "if r['success']:\n",
+    "    image_r = dict(image_basic_req)\n",
+    "    image_r.update({'WorldPt': target})\n",
+    "    status = fc.show_image_or_hips(viewer_id=viewer_id, \n",
+    "                                   image_request=image_r,\n",
+    "                                   hips_request=dict(hips_basic_req), fov_deg_fallover=fov_deg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Regular image is displayed => image_request: {size:yes, target:yes} "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_id = 'hipsDiv5'\n",
+    "r = fc.add_cell(2, 4, 2, 2, 'images', viewer_id)\n",
+    "if r['success']:\n",
+    "    image_r = dict(image_basic_req)\n",
+    "    image_r.update({'WorldPt': target, 'SizeInDeg': size})\n",
+    "    status=fc.show_image_or_hips(viewer_id=viewer_id, \n",
+    "                                 image_request=image_r,\n",
+    "                                 hips_request=dict(hips_basic_req), fov_deg_fallover=fov_deg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All sky is displayed => allsky_request is passed and plot_allsky_first is passed as 'True'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_id = 'hipsDiv6'\n",
+    "r = fc.add_cell(4, 0, 4, 2, 'images', viewer_id)\n",
+    "if r['success']:\n",
+    "    status=fc.show_image_or_hips(viewer_id=viewer_id, \n",
+    "                                image_request=dict(image_basic_req),\n",
+    "                                hips_request=dict(hips_basic_req), allsky_request={'Type': 'ALL_SKY'}, \n",
+    "                                fov_deg_fallover=fov_deg, plot_allsky_first=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -81,12 +81,14 @@ class FireflyClient(WebSocketClient):
         'AddCell': 'layout.addCell',
         'ShowCoverage': 'layout.enableSpecialViewer',
         'ShowImageMetaData': 'layout.enableSpecialViewer',
-        'ReinitViewer': 'app_data.reinitApp'}
+        'ReinitViewer': 'app_data.reinitApp',
+        'ShowHiPS': 'ImagePlotCntlr.PlotHiPS',
+        'ShowImageOrHiPS': 'ImagePlotCntlr.plotHiPSOrImage'}
     """Definition of Firefly action (`dict`)."""
 
     # id for table, region layer, extension
     _item_id = {'Table': 0, 'RegionLayer': 0, 'Extension': 0, 'MaskLayer': 0, 'XYPlot': 0,
-                'Cell': 0, 'Histogram': 0, 'Plotly': 0}
+                'Cell': 0, 'Histogram': 0, 'Plotly': 0, 'Image': 0}
 
     # urls:
     # launch browser:  http://<host>/<basedir>/?__wsch=<channel id> or (mode == 'full')
@@ -98,7 +100,7 @@ class FireflyClient(WebSocketClient):
     def __init__(self, host=_my_localhost, channel=None, basedir='firefly', html_file=None):
         self._basedir = basedir
         self._fftools_cmd = '/%s/sticky/CmdSrv' % self._basedir
-        use_ssl = False
+
         protocol = 'http'
         wsproto = 'ws'
         if host.startswith('http://'):
@@ -107,7 +109,7 @@ class FireflyClient(WebSocketClient):
             host = host[8:]
             protocol = 'https'
             wsproto = 'wss'
-            use_ssl = True
+
         self.this_host = host
 
         url = '%s://%s/%s/sticky/firefly/events' % (wsproto, host, self._basedir)  # web socket url
@@ -122,7 +124,7 @@ class FireflyClient(WebSocketClient):
         self.url_bw = protocol + '://' + self.this_host + '/%s%s?__wsch=' % (self._basedir, self.html_file)
         self.listeners = {}
         self.channel = channel
-        self.headers = {'FF-channel':channel}
+        self.headers = {'FF-channel': channel}
         self.session = requests.Session()
         self.connect()
 
@@ -551,9 +553,7 @@ class FireflyClient(WebSocketClient):
         """
 
         payload = {}
-
-        r = self.dispatch_remote_action_by_post(self.channel, FireflyClient.ACTION_DICT['ReinitViewer'], payload)
-        return r
+        return self.dispatch_remote_action_by_post(self.channel, FireflyClient.ACTION_DICT['ReinitViewer'], payload)
 
     def show_fits(self, file_on_server=None, plot_id=None, viewer_id=None, **additional_params):
         """
@@ -574,7 +574,7 @@ class FireflyClient(WebSocketClient):
         \*\*additional_params : optional keyword arguments
             Any valid fits viewer plotting parameter, please see the details in `fits plotting parameters`_.
 
-            .. _fits plotting parameters: https://github.com/Caltech-IPAC/firefly/blob/dev/docs/fits-plotting-parameters.md
+            .. _fits plotting parameters:https://github.com/Caltech-IPAC/firefly/blob/dev/docs/fits-plotting-parameters.md
 
             More options are shown as below:
 
@@ -946,7 +946,8 @@ class FireflyClient(WebSocketClient):
             **chartId**: `str`, optional
                 The chart ID.
             **data**: `list` of `dict`, optional
-                A list of data for all traces of the plot.ly chart. Firefly-specific keys: *tbl_id*, *firefly* (for Firefly chart types).
+                A list of data for all traces of the plot.ly chart. Firefly-specific keys: *tbl_id*,
+                *firefly* (for Firefly chart types).
             **layout**: `dict`, optional
                 The layout for plot.ly layout. Optional *firefly* key refers to the information processed by Firefly.
 
@@ -1062,6 +1063,125 @@ class FireflyClient(WebSocketClient):
                      'title': title, 'extType': ext_type, 'toolTip': tool_tip}
         payload = {'extension': extension}
         return self.dispatch_remote_action_by_post(self.channel, FireflyClient.ACTION_DICT['AddExtension'],
+                                                   payload)
+
+    def show_hips(self, plot_id=None, viewer_id=None, hips_root_url=None, hips_image_conversion=None,
+                  **additional_params):
+        """
+        Show HiPS image.
+
+        Parameters
+        ----------
+        plot_id : `str`, optional
+            The ID you assign to the image plot. This is necessary to further control the plot.
+        viewer_id : `str`, optional
+            The ID you assign to the viewer (or cell) used to contain the image plot. If grid view is
+            used for display, the viewer id is the cell id of the cell which contains the image plot.
+        hips_root_url : `str`
+            HiPS access URL
+        hips_image_conversion: `dict`, optional
+            The info used to convert between image and HiPS
+        \*\*additional_params : optional keyword arguments
+            parameters for HiPS viewer plotting, the options are shown as below:
+
+            **WorldPt** : `str`, optional
+                World point as the center of the HiPS, if not defined, then get it from HiPS properties or
+                set as the origin of the celestial coordinates.
+            **Title** : `str`, optional
+                Title to display with the HiPS.
+            **SizeInDeg** : `int` or `float`, optional
+                Field of view for HiPS.
+
+        Returns
+        -------
+        out : `dict`
+            Status of the request, like {'success': True}.
+        """
+
+        if not hips_root_url:
+            return
+
+        wp_request = {'plotGroupId': 'groupFromPython',
+                      'hipsRootUrl': hips_root_url}
+        if additional_params:
+            wp_request.update(additional_params)
+
+        payload = {'wpRequest': wp_request}
+
+        if not plot_id:
+            plot_id = FireflyClient._gen_item_id('Image')
+
+        payload.update({'plotId': plot_id})
+        wp_request.update({'plotId': plot_id})
+
+        if not viewer_id:
+            viewer_id = 'DEFAULT_FITS_VIEWER_ID'
+
+        payload.update({'viewerId': viewer_id})
+
+        if hips_image_conversion and type(hips_image_conversion) is dict:
+            payload.update({'hipsImageConversion': hips_image_conversion})
+
+        return self.dispatch_remote_action_by_post(self.channel, FireflyClient.ACTION_DICT['ShowHiPS'],
+                                                   payload)
+
+    def show_image_or_hips(self, plot_id=None, viewer_id=None, image_request=None, hips_request=None,
+                           fov_deg_fallover=0.12, allsky_request=None, plot_allsky_first=False):
+
+        """
+        Show a FiTS or HiPS image.
+
+        Parameters
+        ----------
+        plot_id : `str`, optional
+            The ID you assign to the image plot. This is necessary to further control the plot.
+        viewer_id : `str`, optional
+            The ID you assign to the viewer (or cell) used to contain the image plot. If grid view is
+            used for display, the viewer id is the cell id of the cell which contains the image plot.
+        image_request : `dict`, optional
+            Request with fits plotting parameters. For valid fits viewer plotting parameter, please see the
+            the description of `show_fits` or `show_fits_3color`.
+        hips_request : `dict`, optional
+            Request with hips plotting parameters. For valid HiPS viewer plotting paramter, please see the
+            description of `show_hips`.
+        fov_deg_fallover : `float`, optional
+            The size in degrees that the image will switch between hips and a image cutout.
+        allsky_request : `dict`, optional
+             Allsky type request, like {'Type': 'ALL_SKY'}
+        plot_allsky_first : `bool`, optional
+             Plot all sky first If there is an all sky set up.
+        Returns
+        -------
+        out : `dict`
+            Status of the request, like {'success': True}.
+        """
+
+        if not image_request and not hips_request:
+            return
+
+        if not plot_id:
+            plot_id = FireflyClient._gen_item_id('Image')
+        if not viewer_id:
+            viewer_id = 'DEFAULT_FITS_VIEWER_ID'
+
+        payload = {'fovDegFallOver': fov_deg_fallover, 'plotAllSkyFirst': plot_allsky_first,
+                   'plotId': plot_id, 'viewerId': viewer_id}
+
+        pg_key = 'plotGroupId'
+        if not ((hips_request and hips_request.get(pg_key)) or (image_request and image_request.get(pg_key))):
+            if hips_request:
+                hips_request.update({pg_key: 'groupFromPython'})
+            elif image_request:
+                    image_request.update({pg_key: 'groupFromPython'})
+
+        if image_request:
+            payload.update({'imageRequest': image_request})
+        if hips_request:
+            payload.update({'hipsRequest': hips_request})
+        if allsky_request:
+            payload.update({'allSkyRequest': allsky_request})
+
+        return self.dispatch_remote_action_by_post(self.channel, FireflyClient.ACTION_DICT['ShowImageOrHiPS'],
                                                    payload)
 
     # ----------------------------

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -303,13 +303,15 @@ class FireflyClient(WebSocketClient):
             channel = self.channel
         if not url:
             url = self.url_bw
+
         do_open = True if force else not self._is_page_connected()
+        url = self.get_firefly_url(url, channel)
 
         if do_open:
-            webbrowser.open(self.get_firefly_url(url, channel))
+            webbrowser.open(url)
 
         time.sleep(5)  # todo: find something better to do than sleeping
-        return channel
+        return url
 
     def stay_connected(self):
         """Keep WebSocket connected.


### PR DESCRIPTION
This development includes, 
- adding API show_hips(..)  and show_image_or_hips(..) in 'firefly_client.py' to support HiPS display in sync with those in Firefly. 

Test: 
start jupyter notebook and run slate_hips_test.ipynb in which various HiPS cases are displayed in slate style. 

