### PR TITLE
DM-14227 Load a table from the file containing multiple tables

### DIFF
--- a/examples/basic-demo-tableload.ipynb
+++ b/examples/basic-demo-tableload.ipynb
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we use the irsaviewer application for the server."
+    "In this example we assume the server is running locally, e.g. via a firefly Docker image obtained from https://hub.docker.com/r/ipac/firefly/tags/. "
    ]
   },
   {
@@ -62,11 +62,28 @@
    "outputs": [],
    "source": [
     "host='127.0.0.1:8080'\n",
-    "channel = 'myChannel8'\n",
-    "html = 'firefly.html'\n",
     "\n",
-    "fc = FireflyClient(host, channel=channel, html_file=html)\n",
+    "fc = FireflyClient(host)\n",
     "fc.launch_browser()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The test files uesd below are available in git-lfs repo at https://github.com/lsst/firefly_test_data. <br>\n",
+    "In the following, please set 'testdata_repo_path' to be the path where 'firefly_test_data' is locally located at. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "testdata_repo_path = '/hydra/cm'  # to be reset to where 'firefly_test_data' is located at. "
    ]
   },
   {
@@ -82,9 +99,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "localfile = '/hydra/cm/firefly_test_data/FileUpload-samples/fits/problemFits/src.fits';\n",
+    "localfile = os.path.join(testdata_repo_path, 'firefly_test_data/FileUpload-samples/fits/problemFits/src.fits')\n",
     "filename = fc.upload_file(localfile)\n",
-    "# print(filename)    # file path at Firefly server\n",
     "\n",
     "fc.show_table(filename)"
    ]
@@ -111,11 +127,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "localfile = '/hydra/cm/firefly_test_data/FileUpload-samples/VOTable/tabledata/multiTables_Ned.xml'\n",
+    "localfile = os.path.join(testdata_repo_path, 'firefly_test_data/FileUpload-samples/VOTable/tabledata/multiTables_Ned.xml')\n",
     "filename = fc.upload_file(localfile)\n",
-    "# print(filename)     # file path at Firefly server\n",
     "\n",
-    "fc.show_table(filename, tbl_id='votable-0')\n"
+    "fc.show_table(filename, tbl_id='votable-0')"
    ]
   },
   {

--- a/examples/basic-demo-tableload.ipynb
+++ b/examples/basic-demo-tableload.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API show_table for the file with multiple tables.\n",
+    "\n",
+    "Note that it may be necessary to wait for some cells (like those displaying an table) to complete before executing later cells."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for Python 2/3 compatibility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function, division, absolute_import"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for firefly_client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example we use the irsaviewer application for the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "host='127.0.0.1:8080'\n",
+    "channel = 'myChannel8'\n",
+    "html = 'firefly.html'\n",
+    "\n",
+    "fc = FireflyClient(host, channel=channel, html_file=html)\n",
+    "fc.launch_browser()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load a FITS containing multiple tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "localfile = '/hydra/cm/firefly_test_data/FileUpload-samples/fits/problemFits/src.fits';\n",
+    "filename = fc.upload_file(localfile)\n",
+    "# print(filename)    # file path at Firefly server\n",
+    "\n",
+    "fc.show_table(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc.show_table(filename, table_index=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load a Votable containing multiple tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "localfile = '/hydra/cm/firefly_test_data/FileUpload-samples/VOTable/tabledata/multiTables_Ned.xml'\n",
+    "filename = fc.upload_file(localfile)\n",
+    "# print(filename)     # file path at Firefly server\n",
+    "\n",
+    "fc.show_table(filename, tbl_id='votable-0')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc.show_table(filename, tbl_id='votable-1', table_index=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -649,7 +649,7 @@ class FireflyClient(WebSocketClient):
         return self.dispatch_remote_action_by_post(self.channel, FireflyClient.ACTION_DICT['ShowFits'], payload)
 
     def show_table(self, file_on_server=None, tbl_id=None, title=None, page_size=100, is_catalog=True,
-                   meta=None, target_search_info=None, options=None):
+                   meta=None, target_search_info=None, options=None, table_index=None):
         """
         Show a table.
 
@@ -704,6 +704,10 @@ class FireflyClient(WebSocketClient):
                 if table shows units for the columns.
             **showFilters** : `bool`
                 if table shows filter button
+        table_index : `int`, optional
+            The table to be shown in case `file_on_server` contains multiple tables. It is extension number for
+            a fits file or table index for a votable file. In default, table of extension 1 from a fits file or
+            table of index 0 from a votable file is shown.
 
         Returns
         -------
@@ -727,6 +731,8 @@ class FireflyClient(WebSocketClient):
             tbl_type = 'table' if not is_catalog else 'catalog'
             tbl_req.update({'source': file_on_server, 'tblType': tbl_type,
                             'id': 'IpacTableFromSource'})
+            if table_index:
+                tbl_req.update({'tbl_index': table_index})
         elif target_search_info:
             target_search_info.update(
                     {'use': target_search_info.get('use') if 'use' in target_search_info else 'catalog_overlay'})
@@ -741,7 +747,7 @@ class FireflyClient(WebSocketClient):
 
         return self.dispatch_remote_action_by_post(self.channel, FireflyClient.ACTION_DICT['ShowTable'], payload)
 
-    def fetch_table(self, file_on_server, tbl_id=None, page_size=1):
+    def fetch_table(self, file_on_server, tbl_id=None, page_size=1, table_index=None):
         """
         Fetch table data without showing them
 
@@ -755,6 +761,10 @@ class FireflyClient(WebSocketClient):
             A table ID. It will be created automatically if not specified.
         page_size : `int`, optional
             The number of rows to fetch.
+        table_index : `int`, optional
+            The table to be fetched in case `file_on_server` contains multiple tables. It is extension number for
+            a fits file or table index for a votable file. In default, table of extension 1 from a fits file or
+            table of index 0 from a votable file is fetched.
 
         Returns
         -------
@@ -766,6 +776,9 @@ class FireflyClient(WebSocketClient):
             tbl_id = FireflyClient._gen_item_id('Table')
         tbl_req = {'startIdx': 0, 'pageSize': page_size, 'source': file_on_server,
                    'id': 'IpacTableFromSource', 'tbl_id': tbl_id}
+        if table_index:
+            tbl_req.update({'tbl_index': table_index})
+
         meta_info = {'title': tbl_id, 'tbl_id': tbl_id}
         tbl_req.update({'META_INFO': meta_info})
         payload = {'request': tbl_req, 'hlRowIdx': 0}

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -705,9 +705,9 @@ class FireflyClient(WebSocketClient):
             **showFilters** : `bool`
                 if table shows filter button
         table_index : `int`, optional
-            The table to be shown in case `file_on_server` contains multiple tables. It is extension number for
-            a fits file or table index for a votable file. In default, table of extension 1 from a fits file or
-            table of index 0 from a votable file is shown.
+            The table to be shown in case `file_on_server` contains multiple tables. It is the extension number for
+            a FITS file or the table index for a VOTable file. In unspeficied, the server will fetch extension 1 from
+            a FITS file or the table at index 0 from a VOTable file.
 
         Returns
         -------
@@ -762,9 +762,9 @@ class FireflyClient(WebSocketClient):
         page_size : `int`, optional
             The number of rows to fetch.
         table_index : `int`, optional
-            The table to be fetched in case `file_on_server` contains multiple tables. It is extension number for
-            a fits file or table index for a votable file. In default, table of extension 1 from a fits file or
-            table of index 0 from a votable file is fetched.
+            The table to be fetched in case `file_on_server` contains multiple tables. It is the extension number for
+            a FITS file or the table index for a VOTable file. In unspeficied, the server will fetch extension 1 from
+            a FITS file or the table at index 0 from a VOTable file.
 
         Returns
         -------


### PR DESCRIPTION
the development includes, 
add table_index parameter to show_table and fetch_table to access a table specifically from the file containing multiple tables. 
if table_index is not specified, in default, table of extension 1 from a fits is accessed, and table of index 0 from a votable is accessed. 

test:
'jupyter notebook example' on test sample, basic-demo-tableload.ipynb in which a fits table file and a votable file are uploaded. 
