### PR TITLE
DM-14391 Simplify initialization of display_firefly and firefly_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ Python API for Firefly, IPAC's Advanced Astronomy Web UI Framework
 
 The client must be connected to a Firefly server. The Firefly
 repository is located at http://github.com/Caltech-IPAC/firefly.
-A standalone Firefly server requiring only Java 8 can be obtained from
-https://github.com/Caltech-IPAC/firefly/releases.
+Standalone Firefly servers may be obtained from
+[this Dockerhub repository](https://hub.docker.com/r/ipac/firefly/).
+
+For examples, see [the online documentation](https://firefly-client.lsst.io),
+or [the documentation source file](doc/index.rst).
+
 
 ```
 from firefly_client import FireflyClient
-fc = FireflyClient('localhost:8080', 'mychannel')
+fc = FireflyClient('http://localhost:8080')
 ```
 
 A FITS image may be uploaded and displayed.
@@ -19,4 +23,4 @@ A FITS image may be uploaded and displayed.
 ```
 fval = fc.upload_file('image.fits')
 fc.show_fits(fval, 'myimage')
-
+```

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -115,13 +115,13 @@ Optional arguments for initializing a `FireflyClient` instance include `channel`
 and `html_file`.
 
 For a default server running locally, use `localhost` or `127.0.0.1` together
-with the port that the server is using. The default port is 8080.
+with the port that the server is using, and append `/firefly`. The default port is 8080.
 
 .. code-block:: py
     :name: using-localhost
 
     import firefly_client
-    fc = firefly_client.FireflyClient('http://127.0.0.1:8080')
+    fc = firefly_client.FireflyClient('http://127.0.0.1:8080/firefly')
 
 If the Python session is running on your own machine, you can use the
 :meth:`FireflyClient.launch_browser` method to open up a browser tab.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -63,9 +63,10 @@ please start the Python session in the directory from which you downloaded the s
     :name: gs-start
 
     from firefly_client import FireflyClient
-    fc = FireflyClient('irsa.ipac.caltech.edu:80', basedir='irsaviewer')
+    fc = FireflyClient('https://irsa.ipac.caltech.edu/irsaviewer')
 
-Third, open a new browser tab using the :meth:`FireflyClient.launch_browser` method:
+Third, open a new browser tab using the :meth:`FireflyClient.launch_browser` method. If
+a browser cannot be opened, a URL will be displayed for your web browser.
 
 .. code-block:: py
     :name: gs-launch
@@ -82,7 +83,7 @@ and then showing the image.
     fval = fc.upload_file('2mass-m31-green.fits')
     fc.show_fits(fval)
 
-Fifth, display a table by uloading a catalog table (here, in IPAC format) and
+Fifth, display a table by uploading a catalog table (here, in IPAC format) and
 then showing the table. The sources are also overlaid automatically on the
 image since the catalog contains celestial coordinates, and a default
 chart is displayed.
@@ -105,8 +106,13 @@ Initializing a FireflyClient instance
 -------------------------------------
 
 Once a Firefly server has been identified, the connection parameters can be
-used to initialize a :class:`FireflyClient` instance. A `host:port` parameter is
-required. Optional arguments are `channel` and `basedir`.
+used to initialize a :class:`FireflyClient` instance. By default, the value
+of the environment variable `FIREFLY_URL` will be used as the server URL, if defined. If
+`FIREFLY_URL` is not defined, the default server URL is `http://localhost:8080/firefly`
+which is often used for a Firefly server running locally.
+
+Optional arguments for initializing a `FireflyClient` instance include `channel`
+and `html_file`.
 
 For a default server running locally, use `localhost` or `127.0.0.1` together
 with the port that the server is using. The default port is 8080.
@@ -115,7 +121,7 @@ with the port that the server is using. The default port is 8080.
     :name: using-localhost
 
     import firefly_client
-    fc = firefly_client.FireflyClient('127.0.0.1:8080')
+    fc = firefly_client.FireflyClient('http://127.0.0.1:8080')
 
 If the Python session is running on your own machine, you can use the
 :meth:`FireflyClient.launch_browser` method to open up a browser tab.
@@ -125,8 +131,9 @@ If the Python session is running on your own machine, you can use the
 
     fc.launch_browser()
 
-The :meth:`FireflyClient.launch_browser` method will return the channel string. If the user
-did not specify a channel string, the Firefly server will auto-generate one.
+The :meth:`FireflyClient.launch_browser` method will return two values: a boolean
+indicating whether the web browser open was successful, and the URL for your
+web browser.
 
 .. warning::
 
@@ -138,33 +145,19 @@ did not specify a channel string, the Firefly server will auto-generate one.
 
 If your Python session is not running on your local machine, the
 :meth:`FireflyClient.launch_browser`
-method should not be used. Instead, display the URL to which you must connect
-using :meth:`FireflyClient.get_firefly_url`:
+method will display the URL for your web browser. Alternatively, you can use
+the :meth:`FireflyClient.display_url` method to print the browser URL if
+running in a terminal, and to show a clickable link if running in a
+Jupyter notebook.
 
 .. code-block:: py
 
-    print(fc.get_firefly_url('full'))
+    fc.display_url()
 
-Copy and paste the string into  your address bar. If you are using SSH
-tunneling to connect to your Firefly server, you may need to modify
-the host and port parts of the URL to match your tunnel.
-
-You may set the `channel` parameter to a string of your choosing. In general,
-care should be taken to make the channel unique -- otherwise other users
-of your Firefly server could write to your display.
-
-.. code-block:: py
-
-    fc = firefly_client.FireflyClient('127.0.0.1:8080', channel='qxefvt')
-
-Some Firefly servers do not use the default `basedir` in their URLs. Other
-values in use include `suit` (for LSST) and `irsaviewer` (for applications
-deployed for the Infrared Science Archive). A public server is usually available
-at `http://irsaviewer.ipac.caltech.edu:80/irsaviewer <http://irsaviewer.ipac.caltech.edu:80/irsaviewer>`:
-
-.. code-block:: py
-
-    fc = firefly_client.FireflyClient('irsa.ipac.caltech.edu:80', basedir='irsaviewer')
+In typical usage, it is unnecessary to set the `channel` parameter when
+instantiating `FireflyClient`. A unique string will be auto-generated.
+If you do wish to set the channel explicitly, e.g. for sharing your display
+with someone else, take care to make the channel unique.
 
 .. warning::
 

--- a/examples/basic-demo-tableload.ipynb
+++ b/examples/basic-demo-tableload.ipynb
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we assume the server is running locally, e.g. via a firefly Docker image obtained from https://hub.docker.com/r/ipac/firefly/tags/. "
+    "In this example we assume the server is running locally, e.g. via a Firefly Docker image obtained from https://hub.docker.com/r/ipac/firefly/tags/. "
    ]
   },
   {
@@ -61,10 +61,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "host='127.0.0.1:8080'\n",
+    "url='http://127.0.0.1:8080/firefly'\n",
     "\n",
-    "fc = FireflyClient(host)\n",
-    "fc.launch_browser()"
+    "fc = FireflyClient(url)\n",
+    "localbrowser, browser_url = fc.launch_browser()"
    ]
   },
   {
@@ -72,7 +72,7 @@
    "metadata": {},
    "source": [
     "The test files uesd below are available in git-lfs repo at https://github.com/lsst/firefly_test_data. <br>\n",
-    "In the following, please set 'testdata_repo_path' to be the path where 'firefly_test_data' is locally located at. "
+    "In the following, please set `testdata_repo_path` to be the path where `firefly_test_data` is locally located. "
    ]
   },
   {
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load a Votable containing multiple tables"
+    "## Load a VOTable containing multiple tables"
    ]
   },
   {
@@ -167,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/examples/basic-demo.ipynb
+++ b/examples/basic-demo.ipynb
@@ -26,9 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function, division, absolute_import"
@@ -44,9 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from firefly_client import FireflyClient"
@@ -62,16 +58,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "host='irsa.ipac.caltech.edu:80'\n",
-    "channel = 'myChannel8'\n",
-    "basedir = 'irsaviewer'\n",
-    "\n",
-    "fc = FireflyClient(host, channel=channel, basedir=basedir)"
+    "url='https://irsa.ipac.caltech.edu/irsaviewer'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instantiate `FireflyClient`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc = FireflyClient(url)"
    ]
   },
   {
@@ -93,9 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import astropy.utils.data"
@@ -111,9 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "image_url = ('http://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a' + \n",
@@ -131,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "table_url = (\"http://irsa.ipac.caltech.edu/TAP/sync?FORMAT=IPAC_TABLE&\" +\n",
@@ -153,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. Only works when running the notebook locally."
+    "Open a browser to the firefly server in a new tab. The browser open only works when running the notebook locally, otherwise a link is displayed."
    ]
   },
   {
@@ -162,7 +162,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc.launch_browser()"
+    "localbrowser, browser_url = fc.launch_browser()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the web browser link"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc.display_url()"
    ]
   },
   {
@@ -175,9 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#from IPython.display import IFrame\n",
@@ -195,9 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "imval = fc.upload_file(filename)\n",
@@ -214,9 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "status = fc.show_fits(file_on_server=None, plot_id=\"wise-fullimage\", \n",
@@ -234,9 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "file= fc.upload_file(tablename)\n",
@@ -253,9 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "status = fc.show_xyplot(tbl_id='tablemass', xCol='j_m', yCol='h_m-k_m')"
@@ -271,9 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "status = fc.set_zoom('wise-fullimage', 2)"
@@ -289,9 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "status = fc.set_pan('wise-fullimage', 70, 20, coord='J2000')"
@@ -325,9 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_regions= ['image;polygon 125 25 160 195 150 150 #color=cyan',\n",
@@ -351,15 +351,6 @@
    "source": [
     "fc.remove_region_data(region_data=my_regions[1], region_layer_id='layer1')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -379,7 +370,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/examples/firefly_slate_demo.py
+++ b/examples/firefly_slate_demo.py
@@ -87,14 +87,44 @@ def load_xy(row, col, width, height, fc, cell_id=None):
     r = fc.add_cell(row, col, width, height, 'xyPlots', cell_id)
 
     if r['success']:
-        fc.show_xyplot('tbl_chart', group_id=r['cell_id'], xCol='ra1', yCol='dec1')
+        trace1 = {
+            'tbl_id': 'tbl_chart',
+            'x': "tables::ra1",
+            'y': "tables::dec1",
+            'mode': 'markers',
+            'type': 'scatter',
+            'marker': {'size': 4}}
+        trace_data=[trace1]
+
+        layout_s = {'title': 'Coordinates',
+                    'xaxis': {'title': 'ra1 (deg)'}, 'yaxis': {'title': 'dec1 (deg)'}}
+        fc.show_chart(group_id=r['cell_id'], layout=layout_s, data=trace_data )
 
 
 def load_histogram(row, col, width, height, fc, cell_id=None):
     r = fc.add_cell(row, col, width, height, 'xyPlots', cell_id)
 
     if r['success']:
-        fc.show_histogram('tbl_chart', group_id=r['cell_id'], col='modeint', xOptions='log')
+            histData = [
+                {
+                    'type': 'fireflyHistogram',
+                    'name': 'magzp',
+                    'marker': {'color': 'rgba(153, 51, 153, 0.8)'},
+                    'firefly': {
+                        'tbl_id': 'tbl_chart',
+                        'options': {
+                            'algorithm': 'fixedSizeBins',
+                            'fixedBinSizeSelection': 'numBins',
+                            'numBins': 30,
+                            'columnOrExpr': 'magzp'
+                        }
+                    },
+                }
+            ]
+
+            layout_hist = {'title': 'Magnitude Zeropoints',
+                           'xaxis': {'title': 'magzp'}, 'yaxis': {'title': ''}}
+            result = fc.show_chart(group_id=r['cell_id'], layout=layout_hist, data=histData )
 
 
 def load_first_image_in_random(fc):

--- a/examples/firefly_slate_demo.py
+++ b/examples/firefly_slate_demo.py
@@ -135,6 +135,6 @@ def load_first_image_in_random(fc):
 
 def load_second_image_in_random(fc):
     fc.show_fits(plot_id='xxq', Service='TWOMASS', Title='2mass from service', ZoomType='LEVEL',
-                 initZoomLevel=2, SurveyKey='k', WorldPt='10.68479;41.26906;EQ_J2000',
-                 RangeValues='92,-1,92,2,1,0,1,2,44,120', SizeInDeg='.12')
+                 initZoomLevel=2, SurveyKey='asky', SurveyKeyBand='k',
+                 WorldPt='10.68479;41.26906;EQ_J2000', SizeInDeg='.12')
 

--- a/examples/slate-demo-explicit.ipynb
+++ b/examples/slate-demo-explicit.ipynb
@@ -27,9 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function, division, absolute_import"
@@ -45,9 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from firefly_client import FireflyClient"
@@ -57,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example tentatively uses 127.0.0.1:8080 as the server\n",
+    "This example uses http://127.0.0.1:8080/firefly as the server\n",
     "\n",
     "'slate.html' is a template made for grid view "
    ]
@@ -65,16 +61,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "host='127.0.0.1:8080'\n",
-    "channel = 'myChannel8'\n",
+    "url='http://127.0.0.1:8080/firefly'\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient(host, channel=channel, html_file=html)"
+    "fc = FireflyClient(url, html_file=html)"
    ]
   },
   {
@@ -96,9 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import astropy.utils.data"
@@ -114,9 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fc.launch_browser()"
@@ -132,9 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fc.reinit_viewer()"
@@ -159,9 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r = fc.add_cell(0, 0, 4, 2, 'tables', 'main')\n",
@@ -171,7 +156,7 @@
     "                                           timeout=120, cache=True)\n",
     "    meta_info = {'datasetInfoConverterId': 'SimpleMoving','positionCoordColumns': 'ra_obj;dec_obj;EQ_J2000',\n",
     "                 'datasource': 'image_url'}\n",
-    "    fc.show_table(tbl_name, tbl_id='movingtbl', title='A moving object table', page_size=15, meta=meta_info)\n",
+    "    fc.show_table(fc.upload_file(tbl_name), tbl_id='movingtbl', title='A moving object table', page_size=15, meta=meta_info)\n",
     "    "
    ]
   },
@@ -185,9 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tbl_name = astropy.utils.data.download_file('http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',\n",
@@ -205,9 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tbl_name = astropy.utils.data.download_file(\"http://web.ipac.caltech.edu/staff/roby/demo/test-table4.tbl\", \n",
@@ -226,9 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tbl_name = astropy.utils.data.download_file(\"http://web.ipac.caltech.edu/staff/roby/demo/test-table-m31.tbl\", \n",
@@ -251,9 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r = fc.add_cell(2, 0, 4, 2, 'tableImageMeta', 'image-meta')\n",
@@ -272,9 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r = fc.add_cell(0, 4, 2, 2, 'images', 'wise-cutout')\n",
@@ -295,9 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r = fc.add_cell(2, 4, 2, 2, 'images', 'movingStuff')\n",
@@ -331,15 +304,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r = fc.add_cell(4, 0, 2, 3, 'xyPlots', 'chart-cell-xy')\n",
     "if r['success']:\n",
-    "    fc.show_xyplot('tbl_chart', group_id=r['cell_id'], xCol='ra1', yCol='dec1')\n",
-    "    "
+    "    trace1 = {\n",
+    "        'tbl_id': 'tbl_chart',\n",
+    "        'x': \"tables::ra1\",\n",
+    "        'y': \"tables::dec1\",\n",
+    "        'mode': 'markers',\n",
+    "        'type': 'scatter', \n",
+    "        'marker': {'size': 4}}\n",
+    "    trace_data=[trace1]\n",
+    "    \n",
+    "    layout_s = {'title': 'Coordinates', \n",
+    "                'xaxis': {'title': 'ra1 (deg)'}, 'yaxis': {'title': 'dec1 (deg)'}}   \n",
+    "    fc.show_chart(group_id=r['cell_id'], layout=layout_s, data=trace_data )  "
    ]
   },
   {
@@ -354,14 +335,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r = fc.add_cell(4, 2, 2, 3, 'xyPlots')\n",
     "if r['success']:\n",
-    "    fc.show_histogram('tbl_chart', group_id=r['cell_id'], col='modeint', xOptions='log')"
+    "    histData = [\n",
+    "        {\n",
+    "            'type': 'fireflyHistogram',\n",
+    "            'name': 'magzp', \n",
+    "            'marker': {'color': 'rgba(153, 51, 153, 0.8)'},\n",
+    "            'firefly': {\n",
+    "                'tbl_id': 'tbl_chart',\n",
+    "                'options': {\n",
+    "                    'algorithm': 'fixedSizeBins',\n",
+    "                    'fixedBinSizeSelection': 'numBins',\n",
+    "                    'numBins': 30,\n",
+    "                    'columnOrExpr': 'magzp'\n",
+    "                }\n",
+    "            },\n",
+    "        }\n",
+    "    ]\n",
+    "\n",
+    "    layout_hist = {'title': 'Magnitude Zeropoints',\n",
+    "                   'xaxis': {'title': 'magzp'}, 'yaxis': {'title': ''}}   \n",
+    "    result = fc.show_chart(group_id=r['cell_id'], layout=layout_hist, data=histData )  "
    ]
   },
   {
@@ -377,9 +375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r = fc.add_cell(4, 4, 2, 3, 'coverageImage', 'image-coverage')\n",
@@ -399,9 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "img_name = astropy.utils.data.download_file('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits', \n",
@@ -419,9 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fc.show_fits(plot_id='xxq', Service='TWOMASS', Title='2mass from service', ZoomType='LEVEL',\n",
@@ -432,9 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -456,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/examples/slate-demo-explicit.ipynb
+++ b/examples/slate-demo-explicit.ipynb
@@ -417,8 +417,8 @@
    "outputs": [],
    "source": [
     "fc.show_fits(plot_id='xxq', Service='TWOMASS', Title='2mass from service', ZoomType='LEVEL',\n",
-    "             initZoomLevel=2, SurveyKey='k', WorldPt='10.68479;41.26906;EQ_J2000',\n",
-    "             RangeValues='92,-1,92,2,1,0,1,2,44,120', SizeInDeg='.12')"
+    "             initZoomLevel=2, SurveyKey='asky', SurveyKeyBand='k',\n",
+    "             WorldPt='10.68479;41.26906;EQ_J2000', SizeInDeg='.12')"
    ]
   },
   {

--- a/examples/slate-demo-explicit2.ipynb
+++ b/examples/slate-demo-explicit2.ipynb
@@ -24,8 +24,9 @@
     "Imports for Python 2/3 compatibility\n",
     "Imports for firefly_client\n",
     "\n",
-    "This example tentatively uses 127.0.0.1:8080 as the server\n",
-    "'slate.html' is a template made for grid view \n",
+    "This example uses http://127.0.0.1:8080/firefly as the server.\n",
+    "\n",
+    "'slate.html' is a template made for grid view.\n",
     "\n",
     "Open a browser to the firefly server in a new tab. Only works when running the notebook locally."
    ]
@@ -33,20 +34,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function, division, absolute_import\n",
     "from firefly_client import FireflyClient\n",
     "import astropy.utils.data\n",
     "\n",
-    "host='127.0.0.1:8080'\n",
-    "channel = 'myChannel8'\n",
+    "url='http://127.0.0.1:8080/firefly'\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient(host, channel=channel, html_file=html)\n",
+    "fc = FireflyClient(url, html_file=html)\n",
     "fc.launch_browser()"
    ]
   },
@@ -69,9 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "target = '10.68479;41.26906;EQ_J2000' #Galaxy M31\n",
@@ -100,9 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fc.reinit_viewer()\n",
@@ -310,9 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -334,7 +326,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/examples/slate-demo.ipynb
+++ b/examples/slate-demo.ipynb
@@ -27,9 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function, division, absolute_import"
@@ -45,9 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from firefly_client import FireflyClient"
@@ -57,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example tentatively uses 127.0.0.1:8080 as the server\n",
+    "This example uses http://127.0.0.1:8080/firefly as the server.\n",
     "\n",
     "'slate.html' is a template made for grid view "
    ]
@@ -65,23 +61,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "host='127.0.0.1:8080'\n",
-    "channel = 'myChannel8'\n",
+    "url='http://127.0.0.1:8080/firefly'\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient(host, channel=channel, html_file=html)"
+    "fc = FireflyClient(url, html_file=html)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Dispaly tables, images, XY charts, and Histograms in Window/Grid like layout\n",
+    "## Display tables, images, XY charts, and Histograms in Window/Grid like layout\n",
     "\n",
     "Each rendered unit on Firefly Slate Viewer is called a'cell'. To render a cell and its content, the cell location (row, column, width, height), element type and cell ID are needed. (row, column) and (width, height) represent the position and size of the cell in terms of the grid blocks on Firefly Slate Viewer. Element types include types of 'tables', images', 'xyPlots', 'tableImageMeta' and 'coverageImage'.\n"
    ]
@@ -96,9 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import firefly_slate_demo as fs"
@@ -115,18 +106,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. Only works when running the notebook locally."
+    "Open a browser to the firefly server in a new tab. The browser open only works when running the notebook locally, otherwise the browser url will be displayed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "fc.launch_browser()"
+    "localbrowser, browser_url = fc.launch_browser()"
    ]
   },
   {
@@ -139,9 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# first table in cell 'main' \n",
@@ -151,9 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# add table in cell 'main' for chart and histogram \n",
@@ -163,9 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# add table in cell 'main'\n",
@@ -175,9 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# add table in cell 'main'\n",
@@ -194,9 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show cell containing the image from the active table with datasource column in cell 'main'\n",
@@ -206,9 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show cell containing FITS in cell 'wise-cutout'\n",
@@ -218,9 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show cell with 4 FITS of moving objects in cell 'movingStff'\n",
@@ -237,9 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show xy plot in cell 'chart-cell-xy' associated with the table for chart in cell 'main'\n",
@@ -249,9 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show histogram associated with the table for chart in cell 'main', the cell id is generated by firefly_client\n",
@@ -268,9 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show cell containing coverage image associated with the active table in cell 'main'\n",
@@ -280,9 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show cell containing image in ranmon location without passing the location and cell id\n",
@@ -292,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show second image in random location. This image is located in the same cell as the previous one  \n",
@@ -304,9 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -328,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/examples/slate_hips_test.ipynb
+++ b/examples/slate_hips_test.ipynb
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we use the slate.html application for the server."
+    "In this example we use the slate.html application for a local server."
    ]
   },
   {
@@ -85,11 +85,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "host='127.0.0.1:8080'\n",
-    "channel = 'myChannel8'\n",
+    "url='http://127.0.0.1:8080/firefly'\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient(host, channel=channel, html_file=html)\n",
+    "fc = FireflyClient(url, html_file=html)\n",
     "fc.launch_browser()\n"
    ]
   },
@@ -297,7 +296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -291,6 +291,23 @@ class FireflyClient(WebSocketClient):
 
         return url + channel
 
+    def display_url(self):
+        """
+        Display URL in a user-friendly format
+
+        """
+        try:
+            ipy_str = str(type(get_ipython()))
+            if 'zmqshell' in ipy_str:
+                from IPython.display import display, Markdown
+                display(
+                    Markdown('>Open your web browser to [{}](<a href={} target="_blank">{}</a>)'
+                                 .format([self.get_firefly_url()]*3)))
+                return
+        except:
+            pass
+        print('Open your web browser to {}'.format(self.get_firefly_url()))
+
     def launch_browser(self, url=None, channel=None, force=False, verbose=True):
         """
         Launch a browser with the Firefly Tools viewer and the channel set.

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -277,7 +277,7 @@ class FireflyClient(WebSocketClient):
 
         return url + channel
 
-    def launch_browser(self, url=None, channel=None, force=False):
+    def launch_browser(self, url=None, channel=None, force=False, verbose=True):
         """
         Launch a browser with the Firefly Tools viewer and the channel set.
 
@@ -292,6 +292,8 @@ class FireflyClient(WebSocketClient):
             A different channel than the default (the default is set as *self.channel*).
         force : `bool`, optional
             If the browser page is forced to be opened (the default is *False*).
+        verbose: `bool`, optional
+            If True, print instructions if web browser is not opened (default *True*)
 
         Returns
         -------
@@ -308,10 +310,15 @@ class FireflyClient(WebSocketClient):
         url = self.get_firefly_url(url, channel)
 
         if do_open:
-            webbrowser.open(url)
+            retval = webbrowser.open(url)
+            if retval is True:
+                time.sleep(5)  # todo: find something better to do than sleeping
+            else:
+                if verbose is True:
+                    print('Cannot open web browser. Copy/paste this URL into your browser:')
+                    print(url)
 
-        time.sleep(5)  # todo: find something better to do than sleeping
-        return url
+        return retval, url
 
     def stay_connected(self):
         """Keep WebSocket connected.

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -324,8 +324,10 @@ class FireflyClient(WebSocketClient):
 
         Returns
         -------
-        out : `str`
-            The channel ID.
+        open_success : `bool`
+            If True, the web browser open was successful.
+        url : `str`
+            The URL that is used in the user's web browser.
         """
 
         if not channel:
@@ -335,17 +337,18 @@ class FireflyClient(WebSocketClient):
 
         do_open = True if force else not self._is_page_connected()
         url = self.get_firefly_url(url, channel)
+        open_success = False
 
         if do_open:
-            retval = webbrowser.open(url)
-            if retval is True:
+            open_success = webbrowser.open(url)
+            if open_success is True:
                 time.sleep(5)  # todo: find something better to do than sleeping
             else:
                 if verbose is True:
                     print('Cannot open web browser. Copy/paste this URL into your browser:')
                     print(url)
 
-        return retval, url
+        return open_success, url
 
     def stay_connected(self):
         """Keep WebSocket connected.

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -9,6 +9,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import str
 from ws4py.client.threadedclient import WebSocketClient
+import os
 import requests
 import webbrowser
 import json
@@ -21,6 +22,20 @@ import mimetypes
 import base64
 
 __docformat__ = 'restructuredtext'
+
+if 'FIREFLY_ROUTE' in os.environ:
+    basedir = os.environ['FIREFLY_ROUTE']
+else:
+    basedir = 'firefly'
+
+_my_localhost = 'http://localhost:8080'
+
+if 'FIREFLY_URL' in os.environ:
+    _my_host = os.environ['FIREFLY_URL']
+elif 'EXTERNAL_URL' in os.environ:
+    _my_host = os.environ['EXTERNAL_URL']
+else:
+    _my_host = _my_localhost
 
 
 class FireflyClient(WebSocketClient):
@@ -37,7 +52,6 @@ class FireflyClient(WebSocketClient):
         basedir for the url, e.g. 'firefly' in 'http://localhost:8080/firefly'
     """
 
-    _my_localhost = 'localhost:8080'
     ALL = 'ALL_EVENTS_ENABLED'
     """All events are enabled for the listener (`str`)."""
 
@@ -97,7 +111,7 @@ class FireflyClient(WebSocketClient):
     #                  &cmd=pushAction&Action=<ACTION_DICT>
     # open websocket:  ws://<host>/<basedir>/sticky/firefly/events?channdleID=<channel id>
 
-    def __init__(self, host=_my_localhost, channel=None, basedir='firefly', html_file=None):
+    def __init__(self, host=_my_host, channel=None, basedir=basedir, html_file=None):
         self._basedir = basedir
         self._fftools_cmd = '/%s/sticky/CmdSrv' % self._basedir
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='firefly_client',
-    version='1.3.0',
+    version='2.0.0-dev',
     description='Python API for Firefly',
     author='IPAC LSST SUIT',
     license='BSD',


### PR DESCRIPTION
Modifications to `firefly_client` to make initialization simpler. Since there are API changes involved, the major version is bumped to 2.0.0-dev.

* In `FireflyClient.__init__`, remove the basedir parameter, and rename the first parameter to `url` which now is the URL to the Firefly server.
* At import time, check environment variables `FIREFLY_URL` and `FIREFLY_HTML`. If provided, use these as the defaults for `url` and `html_file`.
* In `launch_browser`, check the return value of the webbrowser open, and return it along with the browser URL. If the browser launch is unsuccessful, display the browser URL, printing if in a terminal and displaying a clickable link if running in a notebook.
* Add `display_url` method to support the changes in `launch_browser`.
* Remove `channel` from example notebooks, and update to use `url` instead of `host`.
* Update the documentation to explain the new initialization of `FireflyClient` and to remove `channel` from the code snippets.