### PR TITLE
DM-14238 High level Python API for Firefly plotting

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -347,7 +347,7 @@ to the Python session:
            dec = float(wdata[1])
            print('ra={:.6f}, dec={:.6f}'.format(ra,dec))
 
-    plistner = fc.add_listener(print_coords)
+    fc.add_listener(print_coords)
 
 To activate the callback in point-selection mode, add it as an extension
 with `ext_type='POINT'`. By default, the title of the extension will appear
@@ -369,7 +369,7 @@ The callback can be deleted with `FireflyClient.remove_listener`:
 
 .. code-block:: py
 
-    fc.remove_listener(plistner)
+    fc.remove_listener(print_coords)
 
 
 

--- a/examples/plot-interface.ipynb
+++ b/examples/plot-interface.ipynb
@@ -134,6 +134,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.utils.data"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -157,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tbl_id = ffplt.upload_table(m31_2mass_fname, title='M31 2MASS')"
+    "tbl_id = ffplt.upload_table(m31_table_fname, title='M31 2MASS')"
    ]
   },
   {
@@ -289,15 +298,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import astropy.utils.data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "wise_tbl_name = astropy.utils.data.download_file('http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',\n",
     "                                            timeout=120, cache=True)"
    ]
@@ -320,6 +320,13 @@
    "source": [
     "ffplt.upload_table(wise_table, title='WISE Demo Table')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/plot-interface.ipynb
+++ b/examples/plot-interface.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates the simplified plot interface. The philosophy of the `plot` module is similar to how `import matplotlib.pyplot as plt` is used to select a backend and make simple plotting commands available, with the object-oriented interface still available for advanced applications."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The goal of the notebook is to easily show tables, make plots, and display images. The data items can be uploaded directly as files to Firefly, or as objects with serialization methods."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize Firefly viewer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the plot method is imported, a search will be conducted for an instance of `FireflyClient`:\n",
+    "\n",
+    "* If the current session includes an operational instance of `FireflyClient` with a web browser connected, it will be used.\n",
+    "* Else, if the environment variable `FIREFLY_URL` is defined, an instance of `FireflyClient` will be created using that URL.\n",
+    "* Else, if there is a Firefly server running locally at `http://localhost:8080/firefly`, it will be used.\n",
+    "* Finally, a short list of public servers will be tried."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import firefly_client.plot as ffplt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next cell will attempt to launch a browser, if there is not already a web page connected to the instance of `FireflyClient`. If the browser launch is unsuccessful, a link will be displayed for your web browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.open_browser()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next cell will display a clickable link"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.display_url()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Optional: specifying a server and channel.\n",
+    "\n",
+    "By default, a channel is generated for you. If you find it more convenient to use a specific server and channel, uncomment out the next cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#import os\n",
+    "#my_channel = os.environ['USER'] + '-plot-module'\n",
+    "#ffplt.reset_server(url='https://lsst-demo.ncsa.illinois.edu/firefly', channel=my_channel)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Restart here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If needed, clear the viewer and reset the layout to the defaults."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.clear()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.reset_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload a table directly from disk."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the case of a file already on disk, pass the path and a title for the table. Here we download a file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m31_table_fname = astropy.utils.data.download_file(\n",
+    "    'http://web.ipac.caltech.edu/staff/roby/demo/m31-2mass-2412-row.tbl',\n",
+    "    timeout=120, cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tbl_id = ffplt.upload_table(m31_2mass_fname, title='M31 2MASS')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a histogram from the last uploaded table, with the minimum required parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.hist('j_m')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a scatter plot from the last uploaded table, with the minimum required parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.scatter('h_m - k_m', 'j_m')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Viewing a Python image object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load a FITS file using astropy.io.fits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.io.fits as fits\n",
+    "m31_image_fname = astropy.utils.data.download_file(\n",
+    "    'http://web.ipac.caltech.edu/staff/roby/demo/2mass-m31-green.fits',\n",
+    "    timeout=120, cache=True)\n",
+    "hdu = fits.open(m31_image_fname)\n",
+    "type(hdu)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upload to the viewer. The return value is the `plot_id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.upload_image(hdu)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Viewing a Numpy array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the `astropy` package is installed, a Numpy array can be uploaded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = hdu[0].data\n",
+    "type(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upload to the viewer. The return value is the `plot_id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.upload_image(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Uploading a Python table object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.utils.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wise_tbl_name = astropy.utils.data.download_file('http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',\n",
+    "                                            timeout=120, cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.table import Table\n",
+    "wise_table = Table.read(wise_tbl_name, format='ipac')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.upload_table(wise_table, title='WISE Demo Table')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/plot-interface.ipynb
+++ b/examples/plot-interface.ipynb
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next cell will attempt to launch a browser, if there is not already a web page connected to the instance of `FireflyClient`. If the browser launch is unsuccessful, a link will be displayed for your web browser."
+    "The next cell will attempt to launch a browser, if there is not already a web page connected to the instance of `FireflyClient`."
    ]
   },
   {
@@ -56,6 +56,13 @@
    "outputs": [],
    "source": [
     "ffplt.open_browser()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the browser launch is unsuccessful, a link will be displayed for your web browser."
    ]
   },
   {
@@ -80,7 +87,7 @@
    "source": [
     "#### Optional: specifying a server and channel.\n",
     "\n",
-    "By default, a channel is generated for you. If you find it more convenient to use a specific server and channel, uncomment out the next cell."
+    "By default, a channel is generated for you. If you find it more convenient to use a specific server and channel, uncomment out the next cell to generate a channel from your username."
    ]
   },
   {
@@ -161,12 +168,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upload the table file from disk, and enable the coverage image"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "tbl_id = ffplt.upload_table(m31_table_fname, title='M31 2MASS')"
+    "tbl_id = ffplt.upload_table(m31_table_fname, title='M31 2MASS', view_coverage=True)"
    ]
   },
   {

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -653,10 +653,11 @@ class FireflyClient(WebSocketClient):
             The ID you assign to the viewer (or cell) used to contain the image plot. If grid view is used for
             display, the viewer id is the cell id of the cell which contains the image plot.
 
-        \*\*additional_params : optional keyword arguments
-            Any valid fits viewer plotting parameter, please see the details in `fits plotting parameters`_.
+        **additional_params : optional keyword arguments
+            Any valid fits viewer plotting parameter, please see the details in `FITS plotting parameters`_.
 
-            .. _fits plotting parameters:https://github.com/Caltech-IPAC/firefly/blob/dev/docs/fits-plotting-parameters.md
+            .. _`FITS plotting parameters`:
+                https://github.com/Caltech-IPAC/firefly/blob/dev/docs/fits-plotting-parameters.md
 
             More options are shown as below:
 
@@ -670,8 +671,8 @@ class FireflyClient(WebSocketClient):
         out : `dict`
             Status of the request, like {'success': True}.
 
-        .. note:: Either `file_on_server` or the target information set by `addition_parameters`
-                  is used for fits search.
+        .. note:: Either `file_on_server` or the target information set by `additional_params`
+                  is used for image search.
         """
 
         wp_request = {'plotGroupId': 'groupFromPython',
@@ -694,14 +695,14 @@ class FireflyClient(WebSocketClient):
 
     def show_fits_3color(self, three_color_params, plot_id=None, viewer_id=None):
         """
-        Show a FITS image by giving the three color requirement
+        Show a 3-color image constructed from the three color parameters
 
         Parameters
         ----------
         three_color_params : `list` of `dict` or `dict`
-            A list or objects contains fits viewer plotting parameters for either all bands or one single band.
-            For valid fits viewer plotting parameter, please see the details in `fits plotting parameters`_ or
-            the description of ****additional_params** in function `show_fits`.
+            A list or objects contains image viewer plotting parameters for either all bands or one single band.
+            For valid image viewer plotting parameter, please see the details in `FITS plotting parameters`_ or
+            the description of **additional_params** in function `show_fits`.
 
         plot_id : `str`, optional
             The ID you assign to the image plot. This is necessary to further control the plot.
@@ -878,7 +879,7 @@ class FireflyClient(WebSocketClient):
         group_id : `str`, optional
             Group ID of the chart group where the chart belongs to. If grid view is used, group id is
             the cell id of the cell which contains the chart.
-        \*\*chart_params : optional keyword arguments
+        **chart_params : optional keyword arguments
             Parameters for XY Plot. The options are shown as below:
 
             **xCol**: `str`
@@ -959,7 +960,7 @@ class FireflyClient(WebSocketClient):
         group_id : `str`, optional
             Group ID of the chart group where the histogram belongs to. If grid view is used, group id is the
             cell id of the cell which contains the histogram.
-        \*\*histogram_params : optional keyword arguments
+        **histogram_params : optional keyword arguments
             Parameters for histogram. The options are shown as below:
 
             **col**: `str`
@@ -1035,7 +1036,7 @@ class FireflyClient(WebSocketClient):
         group_id : `str`, optional
             Group ID of the chart group where the chart belongs to. If grid view is used, group id is
             the cell id of the cell which contains the chart.
-        \*\*chart_params : optional keyword arguments
+        **chart_params : optional keyword arguments
             Parameters for the chart. The options are shown as below:
 
             **chartId**: `str`, optional
@@ -1176,7 +1177,7 @@ class FireflyClient(WebSocketClient):
             HiPS access URL
         hips_image_conversion: `dict`, optional
             The info used to convert between image and HiPS
-        \*\*additional_params : optional keyword arguments
+        **additional_params : optional keyword arguments
             parameters for HiPS viewer plotting, the options are shown as below:
 
             **WorldPt** : `str`, optional
@@ -1353,7 +1354,7 @@ class FireflyClient(WebSocketClient):
             Stretch method (the default is 'percent').
         algorithm : {'linear', 'log','loglog','equal', 'squared', 'sqrt', 'asinh', 'powerlaw_gamma'}, optional
             Stretch algorithm (the default is 'linear').
-        \*\*additional_params : optional keyword arguments
+        **additional_params : optional keyword arguments
             Parameters for changing the stretch. The options are shown as below:
 
             **zscale_contrast** : `int` or  `float`, optional

--- a/firefly_client/plot.py
+++ b/firefly_client/plot.py
@@ -1,0 +1,299 @@
+
+"""
+`firefly_client.plot` is a state-base interface to firefly_client,
+inspired by `matplotlib.pyplot`.
+"""
+
+import logging
+import os
+#import sys
+import tempfile
+import time
+#import urllib
+#from astropy.io import fits
+#from ws4py.client import HandshakeError
+from .firefly_client import FireflyClient
+
+logger = logging.getLogger(__name__)
+
+fc = None
+
+for c in FireflyClient.get_instances():
+    _ = c()
+    if _ and _._is_page_connected():
+        fc = _
+        break
+
+public_urls = ['https://lsst-demo.ncsa.illinois.edu/firefly',
+               'https://irsa.ipac.caltech.edu/irsaviewer']
+
+try_urls = []
+html_file = 'slate.html'
+last_tblid = None
+
+if 'FIREFLY_URL' in os.environ:
+    try_urls.append(os.environ['FIREFLY_URL'])
+if 'FIREFLY_HTML' in os.environ:
+    html_file = os.environ['FIREFLY_HTML']
+
+try_urls.append('http://localhost:8080/firefly')
+try_urls.append('http://127.0.0.1:8080/firefly')
+
+try_urls += public_urls
+
+if fc is None:
+    for url in try_urls:
+        try:
+            logger.debug('attempting to connect to {}'.format(url))
+            fc = FireflyClient(url, html_file=html_file)
+            break
+        except Exception:
+            logger.debug('connection failed to {}'.format(url))
+
+if fc is None:
+    raise RuntimeError('Cannot find existing FireflyClient or valid server URL')
+
+#if not fc._is_page_connected():
+#    fc.launch_browser()
+
+# Set up default cells
+time.sleep(2)
+table_cellid = 'tables'
+plots_cellid = 'plots'
+images_cellid = 'images'
+
+def use_client(ffclient):
+    global fc
+    fc = ffclient
+    if not fc._is_page_connected():
+        open_browser()
+
+def reset_layout():
+    fc.add_cell(row=0, col=0, width=2, height=2, element_type='tables',
+            cell_id=table_cellid)
+    fc.add_cell(row=2, col=0, width=1, height=2, element_type='xyPlots',
+            cell_id=plots_cellid)
+    fc.add_cell(row=2, col=1, width=1, height=2, element_type='images',
+            cell_id=images_cellid)
+
+def reset_server(url, channel=None, html_file=html_file):
+    global fc
+    fc = FireflyClient(url, channel=channel, html_file=html_file)
+
+def display_url():
+    fc.display_url()
+
+def open_browser():
+    fc.launch_browser()
+
+def clear():
+    fc.reinit_viewer()
+
+
+def scatter(x_col, y_col, tbl_id='', size=4, color=None, marker=None,
+            title='', xlabel=None, ylabel=None, cell_id=plots_cellid, **kwargs):
+    """Make a scatter plot from a table uploaded to Firefly
+
+    Parameters:
+    -----------
+    x_col: `str`
+        name of column to use for x-axis data
+    y_col: `str`
+        name of column to use for y-axis data
+    tbl_id: `str`
+        Firefly table ID. If empty, use the ID of the last uploaded table
+    size: `int`
+        marker size. Defaults to 4.
+    color: `str`
+        marker color. None uses the Plotly default
+    marker: `str`
+        marker style. None uses the Plotly default
+    title: `str`
+        plot title. Defaults to empty string
+    xlabel: `str`
+        x-axis label. If None, defaults to xname
+    ylabel: `str`
+        y-axis label. If None, defaults to yname
+    cell_id: `str`
+        ID of Slate cell from add_cell, defaults to table_cellid
+
+
+    """
+    layout = dict(xaxis=dict(title=xlabel if xlabel else x_col),
+                  yaxis=dict(title=ylabel if ylabel else y_col))
+    if title is not None:
+        layout['title'] = title
+    if len(tbl_id) == 0:
+        logger.debug('Using last_tblid: {}'.format(last_tblid))
+        tbl_id = last_tblid
+    trace = dict(tbl_id=tbl_id,
+                x = 'tables::' + x_col,
+                y = 'tables::' + y_col,
+                mode = 'markers',
+                type = 'scatter',
+                marker = dict(size=size))
+    trace.update(kwargs)
+    fc.show_chart(layout=layout, data=[trace], group_id=cell_id)
+
+
+def hist(data_col, tbl_id='', nbins=30, title='', xlabel=None,
+         ylabel=None, cell_id=plots_cellid, **kwargs):
+    """Make a histogram from a table uploaded to Firefly
+
+    data_col: `str`
+        data column name or expression
+    tbl_id: `str`
+        Firefly table ID. If empty, use the ID of the last uploaded table
+    nbins: `int`
+        number of bins to use for histogram. Default 30
+    title: `str`
+        plot title. Defaults to empty string
+    xlabel: `str`
+        x-axis label. If None, defaults to xname
+    ylabel: `str`
+        y-axis label. If None, defaults to yname
+    cell_id: `str`
+        ID of Slate cell from add_cell, defaults to table_cellid
+    """
+    layout = dict(xaxis=dict(title=xlabel if xlabel else data_col),
+                  yaxis=dict(title=ylabel if ylabel else 'Number'))
+    if title is not None:
+        layout['title'] = title
+    if len(tbl_id) == 0:
+        logger.debug('Using last_tblid: {}'.format(last_tblid))
+        tbl_id = last_tblid
+    hist_data = dict(
+        type='fireflyHistogram',
+        name=data_col,
+        marker={'color': 'rgba(153, 51, 153, 0.8)'},
+        firefly=dict(
+            tbl_id=tbl_id,
+            options=dict(
+                algorithm='fixedSizeBins',
+                fixedBinSizeSelection='numBins',
+                numBins=nbins,
+                columnOrExpr=data_col
+            )
+        )
+    )
+    hist_data.update(kwargs)
+    fc.show_chart(group_id=cell_id, layout=layout, data=[hist_data] )
+    return
+
+def upload_table(table, title=None, show=True, write_func="auto", tbl_index=1, page_size=200):
+    """upload a table object to Firefly
+
+    Parameters:
+    -----------
+    table: `str` or table-like object
+        path to table file, or table object to upload
+    title: `str`
+        title of the table, also used as the table ID, if specified. Otherwise auto-generated.
+    show: `bool`
+        display the table in a table viewer in the browser. default True.
+    write_func: `str` or function
+        function for serializing the table. If 'auto', try to auto-discover the write method
+        from the type of the table object and known table types.
+    tbl_index: `int`
+        If the table object contains multiple tables, use the first one.
+    page_size: `int`
+        Number of rows in each page of the table viewer. Default 200.
+
+    Returns:
+    --------
+    tbl_id: `str`
+        Table ID on the Firefly server
+    """
+    if isinstance(table, str):
+        tval = fc.upload_file(table)
+    else:
+        if write_func == 'auto':
+            if 'lsst.afw.table' in str(type(table)):
+                write_func = table.writeFits
+            elif 'astropy.table.table.Table' in str(type(table)):
+                def write_astropy(fname):
+                    atable = table.copy()
+                    for c in atable.colnames:
+                        if len(c) > 68:
+                            atable.rename_column(c, c[:68])
+                    #atable.remove_columns([c for c in table.colnames if len(c) > 68])
+                    import warnings
+                    with warnings.catch_warnings():
+                        warnings.simplefilter('ignore', UserWarning)
+                        atable.write(fname, format='fits', overwrite=True)
+                write_func = write_astropy
+            else:
+                raise RuntimeError('Unable to auto-discover output method for ' + str(type(table)))
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.fits') as fd:
+            write_func(fd.name)
+        tval = fc.upload_file(fd.name)
+        logger.debug('Image name is {}'.format(fd.name))
+        os.remove(fd.name)
+    if title is None:
+        tbl_id = FireflyClient._gen_item_id('Table')
+    else:
+        tbl_id = title
+    if show:
+        status = fc.show_table(tval, tbl_id=tbl_id, title=title, table_index=tbl_index, page_size=page_size)
+    else:
+        status = fc.fetch_table(tval, tbl_id=tbl_id, table_index=tbl_index, page_size=page_size)
+    if status['success']:
+        global last_tblid
+        last_tblid = tbl_id
+        return tbl_id
+    else:
+        raise RuntimeError('table upload unsuccessful')
+
+
+
+def upload_image(image, title=None, write_func='auto', cell_id=images_cellid):
+    """display an array or astropy.io.fits HDU or HDUList
+
+    Parameters:
+    -----------
+    data: 2-D numpy array, or FITS object with write method
+        Data to show in Firefly
+    title: `str`
+        title for the plot, if None then an integer is used
+
+    Returns:
+    --------
+    image_id: `str`
+        Image ID on the Firefly server
+    """
+    if isinstance(image, str):
+        fval = fc.upload_file(image)
+    else:
+        if write_func == 'auto':
+            if 'lsst.afw.image' in str(type(image)):
+                write_func = image.writeFits
+            elif 'astropy.io.fits' in str(type(image)):
+                def write_astropy_image(fname):
+                    import warnings
+                    with warnings.catch_warnings():
+                        warnings.simplefilter('ignore', UserWarning)
+                        image.writeto(fname, overwrite=True)
+                write_func = write_astropy_image
+            elif 'numpy.ndarray' in str(type(image)):
+                import astropy.io.fits
+                hdu = astropy.io.fits.PrimaryHDU(data=image)
+                write_func = lambda fname: hdu.writeto(fname, overwrite=True)
+            else:
+                raise RuntimeError('Unable to auto-discover output method for ' + str(type(table)))
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.fits') as fd:
+            write_func(fd.name)
+        fval = fc.upload_file(fd.name)
+        logger.debug('Image name is {}'.format(fd.name))
+        os.remove(fd.name)
+    if title is None:
+        image_id = FireflyClient._gen_item_id('Image')
+        title=image_id
+    else:
+        image_id = title
+    status = fc.show_fits(fval, plot_id=image_id, title=title, viewer_id=cell_id)
+    if status['success']:
+        global last_imageid
+        last_imageid = image_id
+        return image_id
+    else:
+        raise RuntimeError('image upload and display unsuccessful')


### PR DESCRIPTION
* Add a `plot` module in the spirit of `matplotlib.pyplot`, that provides some simplifications for making plots
   * automatically set up an instance of `FireflyClient`
   * provide convenience functions for uploading Python table objects and image objects
   * keep track of last table uploaded
   * provide simplified `scatter` and `hist` functions that ultimately call `FireflyClient.show_chart`

* In the `FireflyClient` class, keep track of instances in the current Python session

* Documentation fixes.