### PR TITLE
DM-15248 add a test sample to show text region with 'textangle' property

### DIFF
--- a/examples/region-text-demo.ipynb
+++ b/examples/region-text-demo.ipynb
@@ -181,24 +181,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`show_fits` can also display an image from a URL"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#status = fc.show_fits(file_on_server=None, plot_id=\"wise-fullimage\", \n",
-    "#                      URL='http://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a' + \n",
-    "#             '/149/02206a149-w1-int-1b.fits')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },

--- a/examples/region-text-demo.ipynb
+++ b/examples/region-text-demo.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API.\n",
+    "\n",
+    "Note that it may be necessary to wait for some cells (like those displaying an image) to complete before executing later cells."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for Python 2/3 compatibility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function, division, absolute_import"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imports for firefly_client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example we use the irsaviewer application for the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url='http://127.0.0.1:8080/firefly'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instantiate `FireflyClient`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc = FireflyClient(url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download some data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download a sample image and table.\n",
+    "\n",
+    "We use astropy here for convenience, but firefly_client itself does not depend on astropy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.utils.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download a cutout of a WISE band 1 image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_url = ('http://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a' + \n",
+    "            '/149/02206a149-w1-int-1b.fits?center=70,20&size=200pix')\n",
+    "filename = astropy.utils.data.download_file(image_url, cache=True, timeout=120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display tables and catalogs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open a browser to the firefly server in a new tab. The browser open only works when running the notebook locally, otherwise a link is displayed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "localbrowser, browser_url = fc.launch_browser()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the web browser link"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc.display_url()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A local file can be uploaded to the server and then displayed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imval = fc.upload_file(filename)\n",
+    "status = fc.show_fits(file_on_server=imval, plot_id=\"region test\", title='text region test')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`show_fits` can also display an image from a URL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#status = fc.show_fits(file_on_server=None, plot_id=\"wise-fullimage\", \n",
+    "#                      URL='http://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a' + \n",
+    "#             '/149/02206a149-w1-int-1b.fits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Add region data containing text region with 'textangle' property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_regions= [\n",
+    "    'image;text 100 150 # color=pink text={text angle is 30 deg } edit=0 highlite=0  font=\"Times 16 bold normal\" textangle=30',\n",
+    "    'image;text 100 25 # color=pink text={text angle is -20 deg } font=\"Times 16 bold italic\" textangle=-20',\n",
+    "    'circle  80.48446937 77.231180603 13.9268922 #  text={physical;circle ;; color=cyan } color=cyan',\n",
+    "    'image;box 100 150 60 30 30 # color=red text={box on # J2000 with size w=60 & h=30}',\n",
+    "    'circle  80.484469p 77.231180p 3.002392 # color=#B8E986 text={This message has both a \" and \\' in it}']\n",
+    "status = fc.add_region_data(region_data=text_regions, region_layer_id='layerTextRegion',\n",
+    "                  plot_id='region test')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This PR is relevant to Firefly PR, https://github.com/Caltech-IPAC/firefly/pull/657, which allows 'textangle' to be provided in region description and text of region 'text' is displayed with a rotated angle per value of 'textangle'. 

please check the added Jupyter notebook test sample, examples/region-text-demo.ipynb, to see how 'textangle' works for region 'text'. 

