### PR TITLE
DM-13134: fixed panning does not work when one of the two parameters is 0

### DIFF
--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -1419,7 +1419,7 @@ class FireflyClient(WebSocketClient):
         """
 
         payload = {'plotId': plot_id}
-        if x and y:
+        if x is not None and y is not None:
             if coord.startswith('image'):
                 payload.update({'centerPt': {'x': x, 'y': y, 'type': 'ImagePt'}})
             else:


### PR DESCRIPTION
Fixed the panning.  The python code was just checking for zero instead of `not None`

_To Test (from ticket):_

fc.show_fits(fc.upload_file('calexp256.fits'), plot_id='1'

fc.set_pan('1', 1, 1) 
fc.set_pan('1', 0, 0)
fc.set_pan('1', 100, 0)
fc.set_pan('1', 0, 300) 
fc.set_pan('1', 0.5, 300)
fc.set_pan('1', 200, -0.5)

