### PR TITLE
DM-18666 Add support for authorization headers to firefly_client

### DIFF
--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -267,6 +267,9 @@ class FireflyClient(WebSocketClient):
         if location.endswith('/'):
             location = location[:-1]
 
+        if protocol == 'http' and token is not None:
+            raise ValueError('token must be None when url starts with http://')
+
         # auto-generate unique channel if not provided
         channel_matches = False
 

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -65,7 +65,9 @@ class FireflyClient(WebSocketClient):
         If True, and start_tab is true and in use_lab_env is true then start a browser tab. Default False.
     token: `str` or None
         A token for connecting to a Firefly server that requires
-        authentication.
+        authentication. The provided token will be appended to the
+        string "Bearer " to form the value of the "Authorization" header
+        in the sessions attribute.
     """
 
     _instance_cnt = 0
@@ -158,7 +160,9 @@ class FireflyClient(WebSocketClient):
             If True, bring up a Jupyterlab or a browser tab for Firefly. You should almost always take the default.
         token: `str` or None
             A token for connecting to a Firefly server that requires
-            authentication.
+            authentication. The provided token will be appended to the
+            string "Bearer " to form the value of the "Authorization" header
+            in the sessions attribute.
 
         Returns
         -------
@@ -222,7 +226,9 @@ class FireflyClient(WebSocketClient):
             channel.
         token: `str` or None
             A token for connecting to a Firefly server that requires
-            authentication.
+            authentication. The provided token will be appended to the
+            string "Bearer " to form the value of the "Authorization" header
+            in the sessions attribute.
 
         Returns
         -------

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -63,6 +63,9 @@ class FireflyClient(WebSocketClient):
         If True, bring up a Jupyterlab or a browser tab for Firefly. Default False.
     start_browser_tab: `bool`
         If True, and start_tab is true and in use_lab_env is true then start a browser tab. Default False.
+    token: `str` or None
+        A token for connecting to a Firefly server that requires
+        authentication.
     """
 
     _instance_cnt = 0
@@ -130,7 +133,7 @@ class FireflyClient(WebSocketClient):
 
     @staticmethod
     def make_lab_client(start_browser_tab=False, html_file=_my_html_file, start_tab=True,
-                        verbose=False):
+                        verbose=False, token=None):
         """
         Factory method to create a Firefly client in the Jupyterlab environment.
         If you are using Jupyterlab with the jupyter_firefly_extension installed,
@@ -153,6 +156,9 @@ class FireflyClient(WebSocketClient):
             it is defined: otherwise defaults to None.
         start_tab : `bool`, optional
             If True, bring up a Jupyterlab or a browser tab for Firefly. You should almost always take the default.
+        token: `str` or None
+            A token for connecting to a Firefly server that requires
+            authentication.
 
         Returns
         -------
@@ -182,11 +188,12 @@ class FireflyClient(WebSocketClient):
                 print('     Safari: shows an animation to follow on left side bar')
         return FireflyClient(url=_my_url, html_file=html_file,
                              use_lab_env=True, start_tab=start_tab,
-                             start_browser_tab=start_browser_tab)
+                             start_browser_tab=start_browser_tab,
+                             token=token)
 
     @staticmethod
     def make_client(url=_my_url, html_file=_my_html_file, launch_browser=True,
-                    channel_override=None, verbose=False):
+                    channel_override=None, verbose=False, token=None):
         """
         Factory method to create a Firefly client in a plain Python, IPython, or
         notebook session, and attempt to open a display.  If a display cannot be
@@ -213,6 +220,9 @@ class FireflyClient(WebSocketClient):
             string is generated.
             If channel_override is set to a string, it is used for the Firefly
             channel.
+        token: `str` or None
+            A token for connecting to a Firefly server that requires
+            authentication.
 
         Returns
         -------
@@ -233,7 +243,7 @@ class FireflyClient(WebSocketClient):
 
         fc = FireflyClient(url=url, html_file=html_file, channel=channel,
                            use_lab_env=False, start_tab=False,
-                           start_browser_tab=False)
+                           start_browser_tab=False, token=token)
         if verbose:
             print('Firefly URL is {}'.format(fc.get_firefly_url()))
         if launch_browser:
@@ -242,7 +252,7 @@ class FireflyClient(WebSocketClient):
 
     def __init__(self, url=_my_url, channel=None, html_file=_my_html_file,
                  make_default=False, use_lab_env=False, start_tab=False,
-                 start_browser_tab=False):
+                 start_browser_tab=False, token=None):
 
         FireflyClient._instance_cnt += 1
         protocol = 'http'
@@ -288,6 +298,11 @@ class FireflyClient(WebSocketClient):
         self.channel = channel
         self.headers = {'FF-channel': channel}
         self.session = requests.Session()
+        if token is not None:
+            tokstring = 'Bearer {}'.format(token)
+            self.session.headers.update({'Authorization': tokstring})
+            self.extra_headers = [('Authorization', tokstring)]
+
         try:
             self.connect()
         except (ConnectionRefusedError, HandshakeError) as err:

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ setup(
     packages=['firefly_client'],
     install_requires=['ws4py', 'future', 'requests'],
     classifiers=[
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ from setuptools import setup
 
 setup(
     name='firefly_client',
-    version='2.1.1',
+    version='2.2.0-dev',
     description='Python API for Firefly',
     author='IPAC LSST SUIT',
     license='BSD',
     url='http://github.com/Caltech-IPAC/firefly_client',
-    packages = ['firefly_client'],
+    packages=['firefly_client'],
     install_requires=['ws4py', 'future', 'requests'],
     classifiers=[
         'Programming Language :: Python :: 2',
@@ -20,4 +20,3 @@ setup(
         'Programming Language :: Python :: 3.7',
     ]
 )
-

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -28,4 +28,10 @@ class Test(unittest.TestCase):
         """A connection test on an unused socket"""
         port = get_unused_port()
         with self.assertRaises(ValueError):
-            firefly_client.FireflyClient('localhost:{}'.format(port))
+            firefly_client.FireflyClient('http://localhost:{}/firefly'.format(port))
+
+    def test_token_http(self):
+        """A token cannot be used with a non-SSL url"""
+        with self.assertRaises(ValueError):
+            firefly_client.FireflyClient('http://127.0.0.1:8080/firefly',
+                                         token='abcdefghij')


### PR DESCRIPTION
Add support for a string token to be passed to firefly_client.

To make this work, a `token` argument has been added to the `__init__` and factory methods.