### PR TITLE
Firefly-450: show_table now includes a visible parameter and other tweeks

### DIFF
--- a/examples/multi-moc.py
+++ b/examples/multi-moc.py
@@ -1,0 +1,15 @@
+import astropy.utils.data
+from firefly_client import FireflyClient
+fc = FireflyClient.make_client('http://127.0.0.1:8080/firefly', channel_override='moc-channel')
+print('firefly url: {}'.format(fc.get_firefly_url()))
+mocs = ['galex.fits', 'hershel.fits', 'nicmos.fits']
+
+meta = {'PREFERRED_HIPS': 'https://irsa.ipac.caltech.edu/data/hips/CDS/2MASS/Color'}
+for m in mocs:
+    result = input('load {}? (y or n): '.format(m))
+    if result == 'y':
+        downloadName = astropy.utils.data.download_file('http://web.ipac.caltech.edu/staff/roby/demo/moc/{}'.format(m),
+                                            timeout=120, cache=True)
+        serverFile= fc.upload_file(downloadName)
+        fc.fetch_table(serverFile, m, title=m, meta=meta)
+        print(m)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='firefly_client',
-    version='2.2.0',
+    version='2.3.0',
     description='Python API for Firefly',
     author='IPAC LSST SUIT',
     license='BSD',


### PR DESCRIPTION
Firefly-450: show_table now includes a visible parameter and other tweeks

  - tables may now be loaded but not shown in the UI
  - useful for loading MOCs and other types of drawing only tables
  - add multi-moc.py to examples, used for testing MOC loading

https://jira.ipac.caltech.edu/browse/FIREFLY-450

_to test:_

- use `examples/multi-moc.py`
- if you don't have a local build (from firefly PR https://github.com/Caltech-IPAC/firefly/pull/917)
edit `multi-moc.py` and change the firefly url to https://irsawebdev9.ipac.caltech.edu/firefly-480-moc-watcher/firefly/
- `python multi-moc.py` - it should ask to yo load moc's and you should see them in firefly
