### PR TITLE
Firefly-541: firefly_client WebSocket improvements

### DIFF
--- a/firefly_client/__init__.py
+++ b/firefly_client/__init__.py
@@ -1,5 +1,5 @@
 from .firefly_client import FireflyClient
+from .firefly_ws_connections import FFWs
 import pkg_resources
 
 __version__ = pkg_resources.get_distribution("firefly_client").version
-

--- a/firefly_client/firefly_ws_connections.py
+++ b/firefly_client/firefly_ws_connections.py
@@ -1,0 +1,160 @@
+from __future__ import print_function
+from future import standard_library
+from urllib.parse import urljoin
+from ws4py.client.threadedclient import WebSocketClient
+from ws4py.client import HandshakeError
+import json
+
+ALL = 'ALL_EVENTS_ENABLED'
+MAX_CHANNELS = 3
+_connections = {}
+
+
+def _get(channel):
+    if channel in _connections:
+        return _connections[channel]
+
+    class Empty:
+        headers = {'FF-channel': channel}
+        def do_add_listener(self, channel, callback, name=ALL): return
+        def do_remove_listener(self, channel, callback, name=ALL): return
+        def do_run_forever(self): return
+        def disconnect(self): return
+
+    return Empty()
+
+
+class FFWs(WebSocketClient):
+    """
+    For use only by FireflyClient to manage web sockets and channel connections. This class should never be instantiated
+    directly. It should only be used though the static methods
+    """
+
+    @staticmethod
+    def open_ws_connection(channel, wsproto, location):
+        if channel not in _connections:
+            if len(_connections) > MAX_CHANNELS:
+                err_msg = 'You may only use %s channels for a python session' % MAX_CHANNELS
+                raise ConnectionRefusedError(err_msg)
+            _connections[channel] = FFWs(channel, wsproto, location)
+        return _connections[channel]
+
+    @staticmethod
+    def close_ws_connection(channel):
+        _get(channel).disconnect()
+        _connections.pop(channel, None)
+
+    @staticmethod
+    def get_headers(channel): return _get(channel).headers
+
+    @staticmethod
+    def add_listener(channel, callback, name=ALL): _get(channel).do_add_listener(callback, name)
+
+    @staticmethod
+    def remove_listener(channel, callback, name=ALL): _get(channel).do_remove_listener(callback, name)
+
+    @staticmethod
+    def wait_for_events(channel): _get(channel).do_run_forever()
+
+    def __init__(self, channel, wsproto, location):
+
+        ws_url = urljoin('{}://{}/'.format(wsproto, location),
+                         'sticky/firefly/events?channelID={}'.format(channel))
+        WebSocketClient.__init__(self, ws_url)
+        self.channel = channel
+        self.conn_id = None
+        self.headers = {'FF-channel': channel}
+        self.listeners = {}
+
+        try:
+            self.connect()
+        except (ConnectionRefusedError, HandshakeError) as err:
+            err_message = ('Connection refused to URL {}\n'.format(url) +
+                           'You may want to check the URL with your web browser.\n')
+            if ('fireflyLabExtension' in os.environ) and ('fireflyURLLab' in os.environ):
+                err_message += ('\nCheck the Firefly URL in ~/.jupyter/jupyter_notebook_config.py' +
+                                ' or ~/.jupyter/jupyter_notebook_config.json')
+            elif 'FIREFLY_URL' in os.environ:
+                err_message += ('Check setting of FIREFLY_URL environment variable: {}'
+                                .format(os.environ['FIREFLY_URL']))
+            raise ValueError(err_message) from err
+
+    def __handle_event(self, ev):
+        for callback, eventIDList in self.listeners.items():
+            if ev['name'] in eventIDList or ALL in eventIDList:
+                callback(ev)
+
+    def received_message(self, m):
+        """Override the superclass's method
+        """
+        ev = json.loads(m.data.decode('utf8'))
+        event_name = ev['name']
+
+        if event_name == 'EVT_CONN_EST':
+            try:
+                conn_info = ev['data']
+                if self.channel is None:
+                    self.channel = conn_info['channel']
+                if 'connID' in conn_info:
+                    self.conn_id = conn_info['connID']
+
+                self.headers = {'FF-channel': self.channel,
+                                'FF-connID': self.conn_id}
+            except:
+                print('from callback exception: ')
+                print(m)
+        else:
+            self.__handle_event(ev)
+
+    def disconnect(self):
+        """Disconnect the WebSocket.
+        """
+        self.close()
+
+    def do_add_listener(self, callback, name=ALL):
+        """
+        Add a callback function to listen for events on the Firefly client.
+
+        Parameters
+        ----------
+        callback : `Function`
+            The function to be called when a event happens on the Firefly client.
+        name : `str`, optional
+            The name of the events (the default is `ALL`, all events).
+
+        Returns
+        -------
+        out : none
+
+        """
+        if callback not in self.listeners.keys():
+            self.listeners[callback] = []
+        if name not in self.listeners[callback]:
+            self.listeners[callback].append(name)
+
+    def do_remove_listener(self, callback, name=ALL):
+        """
+        Remove an event name from the callback listener.
+
+        Parameters
+        ----------
+        callback : `Function`
+            A previously set callback function.
+        name : `str`, optional
+            The name of the event to be removed from the callback listener
+            (the default is `ALL`, all events).
+
+        Returns
+        -------
+        out : none
+
+        .. note:: `callback` in listener list is removed if all events are removed from the callback.
+        """
+        if callback in self.listeners.keys():
+            if name in self.listeners[callback]:
+                self.listeners[callback].remove(name)
+            if len(self.listeners[callback]) == 0:
+                self.listeners.pop(callback)
+
+    def do_run_forever(self):
+        WebSocketClient.run_forever(self)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='firefly_client',
-    version='2.3.0',
+    version='2.4.0',
     description='Python API for Firefly',
     author='IPAC LSST SUIT',
     license='BSD',

--- a/test/test-5-instances-3-channels.py
+++ b/test/test-5-instances-3-channels.py
@@ -1,0 +1,64 @@
+from firefly_client import FireflyClient
+
+
+def listener1(ev):
+    print('l1')
+    print(ev)
+
+
+def listener2(ev):
+    print('l2')
+    print(ev)
+
+
+def listener3(ev):
+    print('l3')
+    print(ev)
+
+
+def listener4(ev):
+    print('l4')
+    print(ev)
+
+
+lsst_demo_host = 'https://lsst-demo.ncsa.illinois.edu/firefly'
+local_host = 'http://127.0.0.1:8080/firefly'
+host = local_host
+channel1 = 'channel-test-1'
+channel2 = 'channel-test-2'
+channel3 = 'channel-test-3'
+
+
+print("""
+    --------------------------------------------
+    5 instance of firefly that define 3 channels")
+      - since listeners are only added on 2 channels, only two websockets are made")
+      - The first 3 instances use the same channel so they share a websocket")
+      - instance 5 never adds a listener and therefore not websocket is made")
+      - The initial response on the listeners will show the number connections")
+      - example look for something like: channel-test: ['1b4', '1b5']")
+      - You can see this on the server side my monitoring firefly.log")
+    --------------------------------------------
+""")
+
+fc1_c1 = FireflyClient.make_client(host, channel_override=channel1, launch_browser=True)
+fc1_c1.add_extension(ext_type='POINT', title='a point')
+# fc.add_extension(ext_type='LINE_SELECT', title='a line')
+fc2_c1 = FireflyClient.make_client(host, channel_override=channel1, launch_browser=False)
+fc3_c1 = FireflyClient.make_client(host, channel_override=channel1, launch_browser=False)
+fc1_c2 = FireflyClient.make_client(host, channel_override=channel2, launch_browser=True)
+fc1_c2.add_extension(ext_type='POINT', title='a point')
+fc1_c3 = FireflyClient.make_client(host, channel_override=channel3, launch_browser=False)
+print(f'>>>>>> channel: {channel1}, firefly url: {fc1_c1.get_firefly_url()}')
+print(f'>>>>>> channel: {channel2}, firefly url: {fc1_c2.get_firefly_url()}')
+print(f'>>>>>> channel: {channel3}, firefly url: {fc1_c3.get_firefly_url()}')
+
+# ------------ add listeners
+fc1_c1.add_listener(listener1)  # one web socket should be made for first 3 (channel1)
+fc2_c1.add_listener(listener2)
+fc3_c1.add_listener(listener3)
+fc1_c2.add_listener(listener4)  # one web socket should be made for chanel2
+
+# note - no listener added for channel3, so no websocket made
+
+fc1_c1.wait_for_events()

--- a/test/test-socket-not-added-until-listener.ipynb
+++ b/test/test-socket-not-added-until-listener.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient\n",
+    "#import astropy.utils.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This test can be modified to make multiple firefly_clients to prove there is only 1 per channel\n",
+    "lsst_demo_host = 'https://lsst-demo.ncsa.illinois.edu/firefly'\n",
+    "local_host = 'http://127.0.0.1:8080/firefly'\n",
+    "host = local_host\n",
+    "channel1 = 'channel-test-1'\n",
+    "channel2 = 'channel-test-2'\n",
+    "channel3 = 'channel-test-3'\n",
+    "\n",
+    "fc1_c1 = FireflyClient.make_client(host, channel_override=channel1, launch_browser=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "fc1_c1.show_fits(url=\"http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/demo/wise-00.fits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Extensions can be made but there is not web socket connections until a listener is added\n",
+    "\n",
+    "fc1_c1.add_extension(ext_type='LINE_SELECT', title='a line')\n",
+    "fc1_c1.add_extension(ext_type='AREA_SELECT', title='a area')\n",
+    "fc1_c1.add_extension(ext_type='POINT', title='a point')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "l1\n",
+      "{'data': {'payload': {'channel-test-1': ['1e', '2b', '2d']}, 'type': 'app_data.wsConnUpdated'}, 'scope': 'SELF', 'dataType': 'JSON', 'name': 'FLUX_ACTION', 'from': '-1'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A Web socket should not be made until this cell is added\n",
+    "\n",
+    "def listener1(ev):\n",
+    "    print('l1')\n",
+    "    print(ev)\n",
+    "    \n",
+    "fc1_c1.add_listener(listener1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# does not close the web socket, since it might be shared\n",
+    "fc1_c1.remove_listener(listener1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this will actually disconnect the web socket, any other client in this python instance will lose their connection as well\n",
+    "fc1_c1.disconnect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
#### Firefly-541: firefly_client WebSocket improvements

   - WebSockets not created until listener is added
   - Max 3 WebSockets per python instance
   - WebSockets that have the same channel are shared
   - test directory with 2 test created

#### To Test
 
  - There are 2 test in the firefly_client/test
  - Monitor the log file for web sockets connections
  - server: one of:
      - _url_: https://fireflydev.ipac.caltech.edu/firefly/
      - _docker_: `nightly` using 
        - `docker run --rm  -p 8090:8080 -m 4G  --name firefly ipac/firefly:nightly`
      - _local_: build on dev branch
 - The test can also be run against `lsst-demo` but the logging is not quite as good. I cleaned up the logging of websocket a little in the firefly dev branch