### PR TITLE
Firefly-725 multi host listener

### DIFF
--- a/doc/new-release-procedure.md
+++ b/doc/new-release-procedure.md
@@ -1,0 +1,39 @@
+## How to create a firefly_client release
+
+### Procedure
+1. To push a new release you must be a maintainer in pypi ([see pypi below](#pypi))
+1. Bump version in setup.py  (this step is might be done in the PR)
+1. Clean out old distribution 
+   - `rm dist/*`
+1. Create the distribution
+   - Create a tar/gzip file with the correct directory structure
+      - `python setup.py sdist` 
+   - Create the wheel file
+      - `python setup.py bdist_wheel`
+   - check it: `ls dist` should show two files a `.tar.gz` file and a `.whl` file
+1. _Optional_ - At this point you could do an optional test installation ([see below](#optional-test-installation))
+1. Upload to PYPI  
+   - `twine upload  dist/*`
+1. Tag
+   -  `git tag -a 2.5.0`  (replace version number with the current version from setup.py)
+1. If any files were edited (i.e `setup.py`) 
+   - `git commit - a`
+   - `git push origin master`
+1. Push tags
+   - `git push --tags`
+1. After this you can install 
+   - `pip install firefly_client`
+
+### PYPI 
+
+- https://pypi.org/project/firefly-client/
+- Currently two maintainers
+- Testing site: https://test.pypi.org/project/firefly-client/
+
+### Optional Test installation
+
+1. To create a test release you must be a mainainer on testpypi
+1. Create the distribution (see above)
+1. `twine upload --repository-url https://test.pypi.org/legacy/ dist/*`
+1. `pip uninstall firefly_client`
+1. `pip install --verbose --index-url https://testpypi.python.org/pypi firefly_client`

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='firefly_client',
-    version='2.4.2',
+    version='2.5.0',
     description='Python API for Firefly',
     author='IPAC LSST SUIT',
     license='BSD',

--- a/test/test-simple-callback-in-lab.ipynb
+++ b/test/test-simple-callback-in-lab.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,27 +11,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "new instance: http://127.0.0.1:8080/firefly\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'http://127.0.0.1:8080/firefly/?__wsch=channel-test-1'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This test can be modified to make multiple firefly_clients to prove there is only 1 per channel\n",
     "lsst_demo_host = 'https://lsst-demo.ncsa.illinois.edu/firefly'\n",
@@ -48,40 +30,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'success': True}"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fc1_c1.show_fits(url=\"http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/demo/wise-00.fits\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'success': True}"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Extensions can be made but there is not web socket connections until a listener is added\n",
     "\n",
@@ -92,32 +52,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "get channel and calling do_add_listener channel-test-1\n",
-      "adding listener to channel-test-1, ws://127.0.0.1:8080/firefly/sticky/firefly/events?channelID=channel-test-1\n",
-      "__handle_event: REPORT_USER_ACTION\n",
-      "{'data': {'plotId': 'defaultPlotId-1', 'wpt': '202.61265160999017;47.309568861703745;EQ_J2000', 'id': 'Extension-3', 'type': 'POINT', 'ipt': '-11.188491201723878;224.73439125071843', 'plotState': {'ctxStr': 'firefly-geni-6-3', 'zoomLevel': 3.4618645, 'multiImage': 'USE_ALL', 'bandStateAry': [{'workingFitsFileStr': '${cache-dir}/URL-web--926467734-staffrobydemowise-00.fits.fits', 'directFileAccessData': {'dataOffset': 5760, 'bscale': 1, 'naxis1': 222, 'cdelt2': 0.0003819444391411, 'naxis2': 236, 'bzero': 0, 'planeNumber': 0, 'bitpix': '-32', 'blank_value': None}, 'plotRequestSerialize': 'id=ID_NOT_DEFINED&ColorTable=1&ProgressKey=plotRequestKey-0-1614885341257&RequestClass=WebPlotRequest&URL=http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/demo/wise-00.fits&ZoomToHeight=817&ZoomToWidth=1472', 'rangeValuesSerialize': '88,1.0,88,99.0,NaN,2.0,44,25,600,120,0,NaN,1.0'}], 'colorTableId': 1}}, 'scope': 'CHANNEL', 'dataType': 'JSON', 'name': 'REPORT_USER_ACTION'}\n",
-      "\n",
-      "All Listeners for channel: channel-test-1, location: 127.0.0.1:8080/firefly\n",
-      "          ['ALL_EVENTS_ENABLED']\n",
-      "          ['ALL_EVENTS_ENABLED']\n",
-      "callback: REPORT_USER_ACTION\n",
-      "POINT\n",
-      "   image point: -11.188491201723878;224.73439125071843\n",
-      "   world point: 202.61265160999017;47.309568861703745;EQ_J2000\n",
-      "callback: REPORT_USER_ACTION\n",
-      "POINT\n",
-      "   image point: -11.188491201723878;224.73439125071843\n",
-      "   world point: 202.61265160999017;47.309568861703745;EQ_J2000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# A Web socket should not be made until this cell is added\n",
     "\n",

--- a/test/test-simple-callback-in-lab.ipynb
+++ b/test/test-simple-callback-in-lab.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "new instance: http://127.0.0.1:8080/firefly\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'http://127.0.0.1:8080/firefly/?__wsch=channel-test-1'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This test can be modified to make multiple firefly_clients to prove there is only 1 per channel\n",
+    "lsst_demo_host = 'https://lsst-demo.ncsa.illinois.edu/firefly'\n",
+    "local_host = 'http://127.0.0.1:8080/firefly'\n",
+    "irsa = 'http://irsa.ipac.caltech.edu'\n",
+    "fd = 'https://fireflydev.ipac.caltech.edu/firefly'\n",
+    "host = local_host\n",
+    "#host = fd\n",
+    "channel1 = 'channel-test-1'\n",
+    "FireflyClient._debug = True\n",
+    "fc1_c1 = FireflyClient.make_client(host, channel_override=channel1, launch_browser=False)\n",
+    "fc1_c1.get_firefly_url()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc1_c1.show_fits(url=\"http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/demo/wise-00.fits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Extensions can be made but there is not web socket connections until a listener is added\n",
+    "\n",
+    "fc1_c1.add_extension(ext_type='LINE_SELECT', title='a line')\n",
+    "fc1_c1.add_extension(ext_type='AREA_SELECT', title='a area')\n",
+    "fc1_c1.add_extension(ext_type='POINT', title='a point')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "get channel and calling do_add_listener channel-test-1\n",
+      "adding listener to channel-test-1, ws://127.0.0.1:8080/firefly/sticky/firefly/events?channelID=channel-test-1\n",
+      "__handle_event: REPORT_USER_ACTION\n",
+      "{'data': {'plotId': 'defaultPlotId-1', 'wpt': '202.61265160999017;47.309568861703745;EQ_J2000', 'id': 'Extension-3', 'type': 'POINT', 'ipt': '-11.188491201723878;224.73439125071843', 'plotState': {'ctxStr': 'firefly-geni-6-3', 'zoomLevel': 3.4618645, 'multiImage': 'USE_ALL', 'bandStateAry': [{'workingFitsFileStr': '${cache-dir}/URL-web--926467734-staffrobydemowise-00.fits.fits', 'directFileAccessData': {'dataOffset': 5760, 'bscale': 1, 'naxis1': 222, 'cdelt2': 0.0003819444391411, 'naxis2': 236, 'bzero': 0, 'planeNumber': 0, 'bitpix': '-32', 'blank_value': None}, 'plotRequestSerialize': 'id=ID_NOT_DEFINED&ColorTable=1&ProgressKey=plotRequestKey-0-1614885341257&RequestClass=WebPlotRequest&URL=http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/demo/wise-00.fits&ZoomToHeight=817&ZoomToWidth=1472', 'rangeValuesSerialize': '88,1.0,88,99.0,NaN,2.0,44,25,600,120,0,NaN,1.0'}], 'colorTableId': 1}}, 'scope': 'CHANNEL', 'dataType': 'JSON', 'name': 'REPORT_USER_ACTION'}\n",
+      "\n",
+      "All Listeners for channel: channel-test-1, location: 127.0.0.1:8080/firefly\n",
+      "          ['ALL_EVENTS_ENABLED']\n",
+      "          ['ALL_EVENTS_ENABLED']\n",
+      "callback: REPORT_USER_ACTION\n",
+      "POINT\n",
+      "   image point: -11.188491201723878;224.73439125071843\n",
+      "   world point: 202.61265160999017;47.309568861703745;EQ_J2000\n",
+      "callback: REPORT_USER_ACTION\n",
+      "POINT\n",
+      "   image point: -11.188491201723878;224.73439125071843\n",
+      "   world point: 202.61265160999017;47.309568861703745;EQ_J2000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A Web socket should not be made until this cell is added\n",
+    "\n",
+    "def listener1(ev):\n",
+    "    if False:\n",
+    "        print(ev)\n",
+    "    if 'data' not in ev:\n",
+    "        print('no data found in ev')\n",
+    "        return\n",
+    "    data = ev['data']\n",
+    "    if 'payload' in data:\n",
+    "        print(data['payload'])\n",
+    "    if 'type' in data:\n",
+    "        print(data['type'])\n",
+    "        if data['type'] == 'POINT':\n",
+    "            print('   image point: %s' % data['ipt'])\n",
+    "            print('   world point: %s' % data['wpt'])\n",
+    "        if data['type'] == 'LINE_SELECT' or data['type'] == 'AREA_SELECT':\n",
+    "            print('   image points: %s to %s' % (data['ipt0'], data['ipt1']))\n",
+    "            print('   world points: %s to %s' % (data['wpt0'], data['wpt1']))\n",
+    "\n",
+    "\n",
+    "    \n",
+    "fc1_c1.add_listener(listener1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/test-simple-callback-response.py
+++ b/test/test-simple-callback-response.py
@@ -1,0 +1,41 @@
+import json
+from firefly_client import FireflyClient
+
+
+def example_listener(ev):
+    if False:
+        print(ev)
+    if 'data' not in ev:
+        print('no data found in ev')
+        return
+    data = ev['data']
+    if 'payload' in data:
+        print(data['payload'])
+    if 'type' in data:
+        print(data['type'])
+        if data['type'] == 'POINT':
+            print('   image point: %s' % data['ipt'])
+            print('   world point: %s' % data['wpt'])
+        if data['type'] == 'LINE_SELECT' or data['type'] == 'AREA_SELECT':
+            print('   image points: %s to %s' % (data['ipt0'], data['ipt1']))
+            print('   world points: %s to %s' % (data['wpt0'], data['wpt1']))
+
+
+lsst_demo_host = 'https://lsst-demo.ncsa.illinois.edu/firefly'
+local_host = 'http://127.0.0.1:8080/firefly'
+fd = 'https://fireflydev.ipac.caltech.edu/firefly'
+irsa_host = 'https://irsa.ipac.caltech.edu/irsaviewer'
+# host = local_host
+# host = lsst_demo_host
+host = irsa_host
+channel1 = 'channel-test-1'
+
+FireflyClient._debug = True
+fc1_c1 = FireflyClient.make_client(host, channel_override=channel1, launch_browser=True)
+print(fc1_c1.get_firefly_url())
+fc1_c1.add_extension(ext_type='POINT', title='Output Selected Point')
+fc1_c1.add_extension(ext_type='LINE_SELECT', title='Output Selected line')
+fc1_c1.add_extension(ext_type='AREA_SELECT', title='Output Selected Area')
+# ------------ add listener and wait
+fc1_c1.add_listener(example_listener)
+fc1_c1.wait_for_events()


### PR DESCRIPTION
Firefly-725 multi host listener

- Fix: If you create a channel to one host in lab, then create a new fireflyclient instance and
create a channel to a different host with the same channel name, it will _not add the listener for the new host,
firefly_client will add the listener for the old host not the new.
- add some debugging information the can be enabled by FireflyClient._debug = True
- clean up spelling and PEP-8 spacing issues
-  Add release procedure documentation
- version 2.5.0

