### PR TITLE
FIREFLY-1185:Update server links and imports

### DIFF
--- a/examples/basic-demo-tableload.ipynb
+++ b/examples/basic-demo-tableload.ipynb
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, select the IRSA Viewer application as the server (with \"wschannel\" as the WebSocket channel ID and Slate HTML file as the landing page, unless none is needed) and open a new browser tab to its page:"
+    "In this example, we use the IRSA Viewer - a public firefly server. The firefly server can also be run locally, e.g. via a Firefly Docker image obtained from https://hub.docker.com/r/ipac/firefly/tags/. "
    ]
   },
   {
@@ -53,19 +53,15 @@
    "outputs": [],
    "source": [
     "url='https://irsa.ipac.caltech.edu/irsaviewer'\n",
+    "# url=http://127.0.0.1:8080/firefly  # if you have firefly server running locally\n",
     "\n",
-    "#fc = FireflyClient(url, \"wschannel\", html_file=None)\n",
-    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')\n",
-    "localbrowser, browser_url = fc.launch_browser()"
+    "fc = FireflyClient.make_client(url)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Keep in mind other possible servers that run locally can be implemented, such as one via a Firefly Docker image obtained from its related website (https://hub.docker.com/r/ipac/firefly/tags/).\n",
-    "<br>\n",
-    "<br>\n",
     "The following example involves 2 files in different formats that contain multiple tables, 1 FITS and 1 VOTable (in XML style). If none are present, try to get a FITS from KOA (https://koa.ipac.caltech.edu/cgi-bin/KOA/nph-KOAlogin) and a XML VOTable through an Extended Name search on the classic version of NED (https://ned.ipac.caltech.edu/classic) and save them to a local computer path. To obtain the files directly, follow the links below:"
    ]
   },
@@ -93,7 +89,7 @@
    "source": [
     "import os\n",
     "\n",
-    "testdata_repo_path = '/hydra/cm'  # to be reset to a level above where test files are located at"
+    "testdata_repo_path = '/hydra/cm'  # to be reset to where test files are located on your system"
    ]
   },
   {
@@ -116,7 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "localfile = os.path.join(testdata_repo_path, 'firefly_client/MF.20210502.18830.fits')\n",
+    "localfile = os.path.join(testdata_repo_path, 'MF.20210502.18830.fits')\n",
     "filename = fc.upload_file(localfile)\n",
     "\n",
     "fc.show_table(filename)"
@@ -126,7 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Have another table within the FITS file be viewed in the browser (simply the only other one included for the case being looked at):"
+    "Look at another table within the FITS file in the browser (simply the only other one included for the case being looked at):"
    ]
   },
   {
@@ -158,7 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "localfile = os.path.join(testdata_repo_path, 'firefly_client/Mr31objsearch.xml')\n",
+    "localfile = os.path.join(testdata_repo_path, 'Mr31objsearch.xml')\n",
     "filename = fc.upload_file(localfile)\n",
     "\n",
     "fc.show_table(filename, tbl_id='votable-0')"
@@ -205,7 +201,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/basic-demo-tableload.ipynb
+++ b/examples/basic-demo-tableload.ipynb
@@ -4,7 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates basic usage of the firefly_client API show_table for the file with multiple tables.\n",
+    "# Intro"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API method `show_table` for a file with multiple tables.\n",
     "\n",
     "Note that it may be necessary to wait for some cells (like those displaying an table) to complete before executing later cells."
    ]
@@ -20,23 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import print_function, division, absolute_import"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Imports for firefly_client"
+    "Call the imports for firefly_client:"
    ]
   },
   {
@@ -52,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we assume the server is running locally, e.g. via a Firefly Docker image obtained from https://hub.docker.com/r/ipac/firefly/tags/. "
+    "In this example, select the IRSA Viewer application as the server (with \"wschannel\" as the WebSocket channel ID and Slate HTML file as the landing page, unless none is needed) and open a new browser tab to its page:"
    ]
   },
   {
@@ -61,9 +52,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='http://127.0.0.1:8080/firefly'\n",
+    "url='https://irsa.ipac.caltech.edu/irsaviewer'\n",
     "\n",
-    "fc = FireflyClient(url)\n",
+    "#fc = FireflyClient(url, \"wschannel\", html_file=None)\n",
+    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')\n",
     "localbrowser, browser_url = fc.launch_browser()"
    ]
   },
@@ -71,8 +63,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The test files uesd below are available in git-lfs repo at https://github.com/lsst/firefly_test_data. <br>\n",
-    "In the following, please set `testdata_repo_path` to be the path where `firefly_test_data` is locally located. "
+    "Keep in mind other possible servers that run locally can be implemented, such as one via a Firefly Docker image obtained from its related website (https://hub.docker.com/r/ipac/firefly/tags/).\n",
+    "<br>\n",
+    "<br>\n",
+    "The following example involves 2 files in different formats that contain multiple tables, 1 FITS and 1 VOTable (in XML style). If none are present, try to get a FITS from KOA (https://koa.ipac.caltech.edu/cgi-bin/KOA/nph-KOAlogin) and a XML VOTable through an Extended Name search on the classic version of NED (https://ned.ipac.caltech.edu/classic) and save them to a local computer path. To obtain the files directly, follow the links below:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "FITS: https://koa.ipac.caltech.edu/cgi-bin/getKOA/nph-getKOA?filehand=/koadata40/MOSFIRE/20210502/lev0/MF.20210502.18830.fits\n",
+    "<br><br>\n",
+    "VOTable: https://ned.ipac.caltech.edu/cgi-bin/objsearch?objname=M31&extend=no&hconst=73&omegam=0.27&omegav=0.73&corr_z=1&out_csys=Equatorial&out_equinox=J2000.0&obj_sort=RA+or+Longitude&of=xml_all&zv_breaker=30000.0&list_limit=5&img_stamp=YES"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please set `testdata_repo_path` to be the local path where the FITS and VOTable files are located:"
    ]
   },
   {
@@ -83,7 +93,7 @@
    "source": [
     "import os\n",
     "\n",
-    "testdata_repo_path = '/hydra/cm'  # to be reset to where 'firefly_test_data' is located at. "
+    "testdata_repo_path = '/hydra/cm'  # to be reset to a level above where test files are located at"
    ]
   },
   {
@@ -94,15 +104,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upload a file in FITS format that contains multiple tables and display it within the browser (noting that it may likely appear as though only the initial one is visible):"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "localfile = os.path.join(testdata_repo_path, 'firefly_test_data/FileUpload-samples/fits/problemFits/src.fits')\n",
+    "localfile = os.path.join(testdata_repo_path, 'firefly_client/MF.20210502.18830.fits')\n",
     "filename = fc.upload_file(localfile)\n",
     "\n",
     "fc.show_table(filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Have another table within the FITS file be viewed in the browser (simply the only other one included for the case being looked at):"
    ]
   },
   {
@@ -122,15 +146,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upload a file in XML format which functions as a VOTable that contains multiple tables display it within the browser (noting that it may likely appear as though only the initial one is visible):"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "localfile = os.path.join(testdata_repo_path, 'firefly_test_data/FileUpload-samples/VOTable/tabledata/multiTables_Ned.xml')\n",
+    "localfile = os.path.join(testdata_repo_path, 'firefly_client/Mr31objsearch.xml')\n",
     "filename = fc.upload_file(localfile)\n",
     "\n",
     "fc.show_table(filename, tbl_id='votable-0')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Look at another table within the VOTable in the broswer (simply the only other one included for the case being looked at):"
    ]
   },
   {
@@ -167,9 +205,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/basic-demo.ipynb
+++ b/examples/basic-demo.ipynb
@@ -4,7 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates basic usage of the firefly_client API.\n",
+    "# Intro"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API through Python so users can visualize data output without having Firefly installed.\n",
     "\n",
     "Note that it may be necessary to wait for some cells (like those displaying an image) to complete before executing later cells."
    ]
@@ -13,30 +20,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup"
+    "## Repository Setup"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import print_function, division, absolute_import"
+    "Download the folder for firefly_client using git while in bash shell (on Mac or Linux) or Anaconda Prompt app (Windows):\n",
+    "\n",
+    "git clone https://github.com/Caltech-IPAC/firefly_client"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for firefly_client"
+    "## Notebook Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call the imports for firefly_client:"
    ]
   },
   {
@@ -52,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we use the irsaviewer application for the server."
+    "The firefly_client API involves a server in place of having a local install of Firefly on the computer being used. In this example, we use the IRSA Viewer application for the server:"
    ]
   },
   {
@@ -61,14 +68,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='https://irsa.ipac.caltech.edu/irsaviewer'"
+    "url = 'https://irsa.ipac.caltech.edu/irsaviewer'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instantiate `FireflyClient`."
+    "Instantiate `FireflyClient` using the URL above, which in this case involves parameters for WebSocket channel ID (\"wschannel\") and Slate HTML acting as landing page (can choose to have none for following case):"
    ]
   },
   {
@@ -77,23 +84,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc = FireflyClient(url)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Download some data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Download a sample image and table.\n",
+    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')\n",
     "\n",
-    "We use astropy here for convenience, but firefly_client itself does not depend on astropy."
+    "#fc = FireflyClient(url, \"wschannel\", html_file=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download Sample Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the following example, start the process to download a sample image and table by gathering astropy imports for data utility (as firefly_client can use astropy for convenience but is not itself dependent on it):"
    ]
   },
   {
@@ -109,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download a cutout of a WISE band 1 image."
+    "Download a cutout of a WISE band as 1 FITS image:"
    ]
   },
   {
@@ -127,7 +134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download a 2MASS catalog"
+    "Download a 2MASS catalog using an IRSA VO Table Access Protocol ([TAP](https://irsa.ipac.caltech.edu/docs/program_interface/astropy_TAP.html)) search:"
    ]
   },
   {
@@ -146,14 +153,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Display tables and catalogs"
+    "## Display Tables and Catalogs"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. The browser open only works when running the notebook locally, otherwise a link is displayed."
+    "Open a browser to the firefly server in a new tab. Note that the browser open only works when running the notebook locally, otherwise a link is displayed. Test out whether starting a browser tab with IRSA Viewer as the firefly server is possible below:"
    ]
   },
   {
@@ -169,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Display the web browser link"
+    "If it does not open automatically, try using the following command to display a web browser link to click on:"
    ]
   },
   {
@@ -185,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, uncomment the lines below to display the browser application in the notebook."
+    "Alternatively, uncomment the lines below (while commenting out the 2 lines above) to display the browser application in the notebook:"
    ]
   },
   {
@@ -203,7 +210,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A local file can be uploaded to the server and then displayed."
+    "The current example involves 2 images in FITS format to be viewed through the chosen browser, both in different ways.\n",
+    "For the 1st method, upload a local file to the server and then display it (while keeping in mind the `plot_id` parameter chosen):"
    ]
   },
   {
@@ -220,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`show_fits` can also display an image from a URL"
+    "For the 2nd method, pull an image from a URL for `show_fits` to display with a different parameter than above:"
    ]
   },
   {
@@ -238,7 +246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A catalog (with coordinates) will overlay the image by default."
+    "Upload a table from a catalog (with coordinates) to the server so it will overlay the image by default. Note that in the case being looked at, markers can be visible on both \"wise-cutout\" and \"wise-fullimage\" (after checking on one's own time) since they would include the same field of view:"
    ]
   },
   {
@@ -255,7 +263,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An xy plot can be added using the uploaded table data."
+    "Try to add an xy plot using the uploaded table data: ((WIP Note: Error to fix!))"
    ]
   },
   {
@@ -271,7 +279,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Zoom the full image."
+    "Zoom into the full image by a factor of 2 while noting the `plot_id` parameter needed:"
    ]
   },
   {
@@ -287,7 +295,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pan the image to a celestial coordinate."
+    "Pan the full image to center on a given celestial coordinate: ((WIP Note: Error to fix!))"
    ]
   },
   {
@@ -296,14 +304,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "status = fc.set_pan('wise-fullimage', 70, 20, coord='J2000')"
+    "status = fc.set_pan('wise-fullimage', x=70, y=20, coord='J2000')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set the stretch"
+    "Set the stretch for the full image based on IRAF zscale interval with a linear algorithm:"
    ]
   },
   {
@@ -312,16 +320,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "status = fc.set_stretch('wise-fullimage', stype='zscale', algorithm='linear')"
+    "status = fc.set_stretch('wise-fullimage', stype='minmax', algorithm='linear')"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
-    "Add region data"
+    "Add region data to the cutout image (2 areas to begin with):"
    ]
   },
   {
@@ -340,7 +346,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Remove the second region"
+    "Remove the second region whlie keeping the first one visible:"
    ]
   },
   {
@@ -351,6 +357,13 @@
    "source": [
     "fc.remove_region_data(region_data=my_regions[1], region_layer_id='layer1')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -370,9 +383,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/basic-demo.ipynb
+++ b/examples/basic-demo.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates basic usage of the firefly_client API through Python so users can visualize data output without having Firefly installed.\n",
+    "This notebook demonstrates basic usage of the firefly_client API.\n",
     "\n",
     "Note that it may be necessary to wait for some cells (like those displaying an image) to complete before executing later cells."
    ]
@@ -20,30 +20,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Repository Setup"
+    "## Setup"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download the folder for firefly_client using git while in bash shell (on Mac or Linux) or Anaconda Prompt app (Windows):\n",
-    "\n",
-    "git clone https://github.com/Caltech-IPAC/firefly_client"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Notebook Setup"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Call the imports for firefly_client:"
+    "Imports for firefly_client:"
    ]
   },
   {
@@ -59,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The firefly_client API involves a server in place of having a local install of Firefly on the computer being used. In this example, we use the IRSA Viewer application for the server:"
+    "The firefly_client needs to connect to a firefly server. In this example, we use the IRSA Viewer application for the server:"
    ]
   },
   {
@@ -75,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instantiate `FireflyClient` using the URL above, which in this case involves parameters for WebSocket channel ID (\"wschannel\") and Slate HTML acting as landing page (can choose to have none for following case):"
+    "Instantiate `FireflyClient` using the URL above:"
    ]
   },
   {
@@ -84,9 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')\n",
-    "\n",
-    "#fc = FireflyClient(url, \"wschannel\", html_file=None)"
+    "fc = FireflyClient.make_client(url)"
    ]
   },
   {
@@ -100,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the following example, start the process to download a sample image and table by gathering astropy imports for data utility (as firefly_client can use astropy for convenience but is not itself dependent on it):"
+    "For the following example, we download a sample image and table by using astropy (it's used only for convenience, firefly_client itself does not depend on astropy):"
    ]
   },
   {
@@ -160,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. Note that the browser open only works when running the notebook locally, otherwise a link is displayed. Test out whether starting a browser tab with IRSA Viewer as the firefly server is possible below:"
+    "Instantiating FireflyClient should open a browser to the firefly server in a new tab. You can also achieve this using the following method. The browser open only works when running the notebook locally, otherwise a link is displayed."
    ]
   },
   {
@@ -169,7 +151,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "localbrowser, browser_url = fc.launch_browser()"
+    "# localbrowser, browser_url = fc.launch_browser()"
    ]
   },
   {
@@ -211,7 +193,7 @@
    "metadata": {},
    "source": [
     "The current example involves 2 images in FITS format to be viewed through the chosen browser, both in different ways.\n",
-    "For the 1st method, upload a local file to the server and then display it (while keeping in mind the `plot_id` parameter chosen):"
+    "For the 1st method, upload a local file to the server and then display it:"
    ]
   },
   {
@@ -228,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the 2nd method, pull an image from a URL for `show_fits` to display with a different parameter than above:"
+    "For the 2nd method, pull an image directly from a URL:"
    ]
   },
   {
@@ -246,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Upload a table from a catalog (with coordinates) to the server so it will overlay the image by default. Note that in the case being looked at, markers can be visible on both \"wise-cutout\" and \"wise-fullimage\" (after checking on one's own time) since they would include the same field of view:"
+    "Upload a catalog table (with coordinates) to the server so it will overlay the image with markers by default. Note that markers can be visible on both \"wise-cutout\" and \"wise-fullimage\" since they would include the same field of view:"
    ]
   },
   {
@@ -263,7 +245,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Try to add an xy plot using the uploaded table data: ((WIP Note: Error to fix!))"
+    "Add an xy plot using the uploaded table data:"
    ]
   },
   {
@@ -279,7 +261,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Zoom into the full image by a factor of 2 while noting the `plot_id` parameter needed:"
+    "Zoom into the full image by a factor of 2 (note the `plot_id` parameter we used earlier):"
    ]
   },
   {
@@ -295,7 +277,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pan the full image to center on a given celestial coordinate: ((WIP Note: Error to fix!))"
+    "Pan the full image to center on a given celestial coordinate:"
    ]
   },
   {
@@ -320,7 +302,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "status = fc.set_stretch('wise-fullimage', stype='minmax', algorithm='linear')"
+    "status = fc.set_stretch('wise-fullimage', stype='zscale', algorithm='linear')"
    ]
   },
   {

--- a/examples/basic_3color.ipynb
+++ b/examples/basic_3color.ipynb
@@ -6,13 +6,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function, division, absolute_import\n",
     "from firefly_client import FireflyClient\n",
     "\n",
-    "url='http://127.0.0.1:8080/firefly'\n",
-    "html = 'slate.html'\n",
+    "url='https://irsa.ipac.caltech.edu/irsaviewer'\n",
     "\n",
-    "fc = FireflyClient(url, html_file=html)\n",
+    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')\n",
+    "#fc = FireflyClient(url, \"wschannel\", html_file=None)\n",
     "fc.launch_browser()"
    ]
   },
@@ -108,9 +107,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/basic_3color.ipynb
+++ b/examples/basic_3color.ipynb
@@ -9,10 +9,9 @@
     "from firefly_client import FireflyClient\n",
     "\n",
     "url='https://irsa.ipac.caltech.edu/irsaviewer'\n",
+    "# url=http://127.0.0.1:8080/firefly  # if you have firefly server running locally\n",
     "\n",
-    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')\n",
-    "#fc = FireflyClient(url, \"wschannel\", html_file=None)\n",
-    "fc.launch_browser()"
+    "fc = FireflyClient.make_client(url)"
    ]
   },
   {
@@ -107,7 +106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/lsst_footprint_demo.ipynb
+++ b/examples/lsst_footprint_demo.ipynb
@@ -27,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Call the firefly_client and data utility in astropy imports separately:"
+    "Imports for firefly_client: "
    ]
   },
   {
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, use IRSA Viewer as the server:"
+    "In this example, we use local firefly server (you can also use public server - irsaviewer instead):"
    ]
   },
   {
@@ -61,14 +61,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://irsa.ipac.caltech.edu/irsaviewer'"
+    "url = 'http://127.0.0.1:8080/firefly'\n",
+    "# url = 'https://irsa.ipac.caltech.edu/irsaviewer'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instantiate `FireflyClient` using the URL above, which in this case involves parameters for WebSocket channel ID (\"wschannel\") and HTML acting as landing page (Slate):"
+    "Instantiate `FireflyClient` using the url above."
    ]
   },
   {
@@ -77,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')"
+    "fc = FireflyClient.make_client(url)"
    ]
   },
   {
@@ -91,23 +92,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. Note that the browser open only works when running the notebook locally, otherwise a link is displayed. Check whether a tab using an IRSA Viewer page starts below:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "localbrowser, browser_url = fc.launch_browser()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The data used in this example are taken from http://web.ipac.caltech.edu/staff/shupe/firefly_testdata and can be downloaded. Pull a file using the image URL below and upload it onto the server:"
+    "The data used in this example are taken from http://web.ipac.caltech.edu/staff/shupe/firefly_testdata and can be downloaded. Download a file using the image URL below and upload it to the server:"
    ]
   },
   {
@@ -149,7 +134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Upload a table with footprint data, using another specific URL where the file to download can be located:"
+    "Upload a table with footprint data using the foloowing url from where it can be downloaded:"
    ]
   },
   {
@@ -210,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/lsst_footprint_demo.ipynb
+++ b/examples/lsst_footprint_demo.ipynb
@@ -4,7 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates basic usage of the firefly_client API, overlay_footprints, which overlays the footprint described in image pixel of JSON format on the fits image "
+    "# Intro"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API method `overlay_footprints` which overlays the footprint described in image pixel of JSON format on a FITS image.\n",
+    "\n",
+    "Note that it may be necessary to wait for some cells (like those displaying an table) to complete before executing later cells."
    ]
   },
   {
@@ -18,23 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import print_function, division, absolute_import"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Imports for firefly_client"
+    "Call the firefly_client and data utility in astropy imports separately:"
    ]
   },
   {
@@ -59,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we use the local Firefly server."
+    "In this example, use IRSA Viewer as the server:"
    ]
   },
   {
@@ -68,14 +61,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'http://127.0.0.1:8080/firefly'"
+    "url = 'https://irsa.ipac.caltech.edu/irsaviewer'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instantiate `FireflyClient`."
+    "Instantiate `FireflyClient` using the URL above, which in this case involves parameters for WebSocket channel ID (\"wschannel\") and HTML acting as landing page (Slate):"
    ]
   },
   {
@@ -84,21 +77,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc = FireflyClient(url)"
+    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Download some data"
+    "## Start with Image Data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. The browser open only works when running the notebook locally, otherwise a link is displayed."
+    "Open a browser to the firefly server in a new tab. Note that the browser open only works when running the notebook locally, otherwise a link is displayed. Check whether a tab using an IRSA Viewer page starts below:"
    ]
   },
   {
@@ -114,7 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The data used in this example are taken from http://web.ipac.caltech.edu/staff/shupe/firefly_testdata"
+    "The data used in this example are taken from http://web.ipac.caltech.edu/staff/shupe/firefly_testdata and can be downloaded. Pull a file using the image URL below and upload it onto the server:"
    ]
   },
   {
@@ -125,8 +118,14 @@
    "source": [
     "image_url = 'http://web.ipac.caltech.edu/staff/shupe/firefly_testdata/calexp-subset-HSC-R.fits'\n",
     "filename = astropy.utils.data.download_file(image_url, cache=True, timeout=120)\n",
-    "imval = fc.upload_file(filename)\n",
-    "plotid = 'footprinttest'"
+    "imval = fc.upload_file(filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the `plot_id` for the image and display it through the opened browser:"
    ]
   },
   {
@@ -135,7 +134,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plotid = 'footprinttest'\n",
     "status = fc.show_fits(file_on_server=imval, plot_id=plotid, title='footprints HSC R-band')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add Data for Footprints"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upload a table with footprint data, using another specific URL where the file to download can be located:"
    ]
   },
   {
@@ -147,6 +161,13 @@
     "table_url = 'http://web.ipac.caltech.edu/staff/shupe/firefly_testdata/footprints-subset-HSC-R.xml'\n",
     "footprint_table = astropy.utils.data.download_file(table_url, cache=True, timeout=120)\n",
     "tableval = fc.upload_file(footprint_table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Overlay a footprint layer (while comparing a highlighted section to the overall footprint) onto the plot using the above table:"
    ]
   },
   {
@@ -169,9 +190,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    ""
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -184,16 +203,16 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/plot-interface.ipynb
+++ b/examples/plot-interface.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "from firefly_client import FireflyClient\n",
     "import firefly_client.plot as ffplt\n",
-    "fc = FireflyClient('https://irsa.ipac.caltech.edu/irsaviewer', \"wschannel\", html_file='slate.html')\n",
+    "fc = FireflyClient.make_client('https://irsa.ipac.caltech.edu/irsaviewer')\n",
     "ffplt.use_client(fc)"
    ]
   },
@@ -141,13 +141,6 @@
    "metadata": {},
    "source": [
     "### Upload a table directly from disk."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Call the imports from astropy to download files (in this case from provided links)"
    ]
   },
   {
@@ -320,7 +313,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load a table using astropy to get the file"
+    "Load a table using astropy"
    ]
   },
   {
@@ -337,7 +330,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Call import from astropy to handle tables and read the downloaded one in IPAC table format"
+    "Read the downloaded table in IPAC table format"
    ]
   },
   {
@@ -390,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/plot-interface.ipynb
+++ b/examples/plot-interface.ipynb
@@ -39,7 +39,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import firefly_client.plot as ffplt"
+    "from firefly_client import FireflyClient\n",
+    "import firefly_client.plot as ffplt\n",
+    "fc = FireflyClient('https://irsa.ipac.caltech.edu/irsaviewer', \"wschannel\", html_file='slate.html')\n",
+    "ffplt.use_client(fc)"
    ]
   },
   {
@@ -138,6 +141,13 @@
    "metadata": {},
    "source": [
     "### Upload a table directly from disk."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call the imports from astropy to download files (in this case from provided links)"
    ]
   },
   {
@@ -307,6 +317,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load a table using astropy to get the file"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -317,6 +334,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call import from astropy to handle tables and read the downloaded one in IPAC table format"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -324,6 +348,13 @@
    "source": [
     "from astropy.table import Table\n",
     "wise_table = Table.read(wise_tbl_name, format='ipac')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upload to the viewer with a set title"
    ]
   },
   {
@@ -359,9 +390,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/region-text-demo.ipynb
+++ b/examples/region-text-demo.ipynb
@@ -4,7 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates basic usage of the firefly_client API.\n",
+    "# Intro"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates basic usage of the firefly_client API involving how to add region data with text to a FITS image.\n",
     "\n",
     "Note that it may be necessary to wait for some cells (like those displaying an image) to complete before executing later cells."
    ]
@@ -20,23 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import print_function, division, absolute_import"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Imports for firefly_client"
+    "Call the imports for firefly_client:"
    ]
   },
   {
@@ -52,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we use the irsaviewer application for the server."
+    "In this example, use the IRSA Viewer application for the server:"
    ]
   },
   {
@@ -61,14 +52,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='http://127.0.0.1:8080/firefly'"
+    "url='https://irsa.ipac.caltech.edu/irsaviewer'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instantiate `FireflyClient`."
+    "Instantiate `FireflyClient` using the URL above, which in this case involves parameters for WebSocket channel ID (\"wschannel\") and HTML acting as landing page (None):"
    ]
   },
   {
@@ -77,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc = FireflyClient(url)"
+    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')"
    ]
   },
   {
@@ -93,7 +84,7 @@
    "source": [
     "Download a sample image and table.\n",
     "\n",
-    "We use astropy here for convenience, but firefly_client itself does not depend on astropy."
+    "Though firefly_client itself does not depend on astropy and can work otherwise, gather data utility imports for astropy to use it here for convenience:"
    ]
   },
   {
@@ -109,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download a cutout of a WISE band 1 image."
+    "Download a cutout of a WISE band as 1 FITS image:"
    ]
   },
   {
@@ -134,7 +125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. The browser open only works when running the notebook locally, otherwise a link is displayed."
+    "Open a browser to the firefly server in a new tab. Note that the browser open only works when running the notebook locally, otherwise a link is displayed. Check whether a tab using an IRSA Viewer page starts below:"
    ]
   },
   {
@@ -150,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Display the web browser link"
+    "If it does not open automatically, try using the following command to display a web browser link to click on:"
    ]
   },
   {
@@ -166,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A local file can be uploaded to the server and then displayed."
+    "Upload a local file to the server and then display it (while keeping in mind the `plot_id` parameter being chosen):"
    ]
   },
   {
@@ -181,9 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "Add region data containing text region with 'textangle' property"
    ]
@@ -229,9 +218,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/region-text-demo.ipynb
+++ b/examples/region-text-demo.ipynb
@@ -27,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Call the imports for firefly_client:"
+    "Imports for firefly_client:"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, use the IRSA Viewer application for the server:"
+    "In this example, we use the IRSA Viewer application for firefly server:"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instantiate `FireflyClient` using the URL above, which in this case involves parameters for WebSocket channel ID (\"wschannel\") and HTML acting as landing page (None):"
+    "Instantiate `FireflyClient` using the URL above:"
    ]
   },
   {
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc = FireflyClient(url, \"wschannel\", html_file='slate.html')"
+    "fc = FireflyClient.make_client(url)"
    ]
   },
   {
@@ -84,7 +84,7 @@
    "source": [
     "Download a sample image and table.\n",
     "\n",
-    "Though firefly_client itself does not depend on astropy and can work otherwise, gather data utility imports for astropy to use it here for convenience:"
+    "We use astropy here for convenience, but firefly_client itself does not depend on astropy."
    ]
   },
   {
@@ -125,7 +125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. Note that the browser open only works when running the notebook locally, otherwise a link is displayed. Check whether a tab using an IRSA Viewer page starts below:"
+    "Instantiating FireflyClient should open a browser to the firefly server in a new tab. You can also achieve this using the following method. The browser open only works when running the notebook locally, otherwise a link is displayed."
    ]
   },
   {
@@ -134,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "localbrowser, browser_url = fc.launch_browser()"
+    "# localbrowser, browser_url = fc.launch_browser()"
    ]
   },
   {
@@ -218,7 +218,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/slate-demo-explicit.ipynb
+++ b/examples/slate-demo-explicit.ipynb
@@ -37,9 +37,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example uses the IRSA Viewer application (https://irsa.ipac.caltech.edu) as the server.\n",
+    "This example uses http://127.0.0.1:8080/firefly as the server, and 'slate.html' as the html file which is a template made for grid view.\n",
     "\n",
-    "'slate.html' is a template made for grid view."
+    "Both of these are passed by default if there are no corresponding environment variables set, but we're still passing them explicitly for clarity."
    ]
   },
   {
@@ -48,10 +48,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='https://irsa.ipac.caltech.edu/irsaviewer/'\n",
+    "url='http://127.0.0.1:8080/firefly'  # you can also use public server: https://irsa.ipac.caltech.edu/irsaviewer/\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient.make_client(url)"
+    "fc = FireflyClient.make_client(url, html_file=html)"
    ]
   },
   {
@@ -83,7 +83,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. Only works when running the notebook locally."
+    "Instantiating FireflyClient should open a browser to the firefly server in a new tab. You can also achieve this using the following method. The browser open only works when running the notebook locally."
    ]
   },
   {
@@ -92,7 +92,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc.launch_browser()"
+    "# fc.launch_browser()"
    ]
   },
   {
@@ -430,7 +430,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/slate-demo-explicit.ipynb
+++ b/examples/slate-demo-explicit.ipynb
@@ -21,22 +21,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import print_function, division, absolute_import"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Imports for firefly_client"
    ]
   },
@@ -53,9 +37,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example uses http://127.0.0.1:8080/firefly as the server\n",
+    "This example uses the IRSA Viewer application (https://irsa.ipac.caltech.edu) as the server.\n",
     "\n",
-    "'slate.html' is a template made for grid view "
+    "'slate.html' is a template made for grid view."
    ]
   },
   {
@@ -64,10 +48,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='http://127.0.0.1:8080/firefly'\n",
+    "url='https://irsa.ipac.caltech.edu/irsaviewer/'\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient(url, html_file=html)"
+    "fc = FireflyClient.make_client(url)"
    ]
   },
   {
@@ -446,9 +430,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/slate-demo-explicit2.ipynb
+++ b/examples/slate-demo-explicit2.ipynb
@@ -21,7 +21,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for firefly_client and astropy"
+    "Imports for firefly_client"
    ]
   },
   {
@@ -39,11 +39,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example uses the IRSA Viewer application (https://irsa.ipac.caltech.edu) as the server.\n",
+    "This example uses http://127.0.0.1:8080/firefly as the server, and 'slate.html' as the html file which is a template made for grid view.\n",
     "\n",
-    "'slate.html' is a template made for grid view.\n",
-    "\n",
-    "Open a browser to the firefly server in a new tab. Only works when running the notebook locally."
+    "Both of these are passed by default if there are no corresponding environment variables set, but we're still passing them explicitly for clarity."
    ]
   },
   {
@@ -52,11 +50,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='https://irsa.ipac.caltech.edu/irsaviewer/'\n",
+    "url='http://127.0.0.1:8080/firefly'  # you can also use public server: https://irsa.ipac.caltech.edu/irsaviewer/\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient.make_client(url)\n",
-    "fc.launch_browser()"
+    "fc = FireflyClient.make_client(url, html_file=html)"
    ]
   },
   {
@@ -337,7 +334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/slate-demo-explicit2.ipynb
+++ b/examples/slate-demo-explicit2.ipynb
@@ -21,10 +21,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility\n",
-    "Imports for firefly_client\n",
+    "Imports for firefly_client and astropy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient\n",
     "\n",
-    "This example uses http://127.0.0.1:8080/firefly as the server.\n",
+    "import astropy.utils.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example uses the IRSA Viewer application (https://irsa.ipac.caltech.edu) as the server.\n",
     "\n",
     "'slate.html' is a template made for grid view.\n",
     "\n",
@@ -37,14 +52,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function, division, absolute_import\n",
-    "from firefly_client import FireflyClient\n",
-    "import astropy.utils.data\n",
-    "\n",
-    "url='http://127.0.0.1:8080/firefly'\n",
+    "url='https://irsa.ipac.caltech.edu/irsaviewer/'\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient(url, html_file=html)\n",
+    "fc = FireflyClient.make_client(url)\n",
     "fc.launch_browser()"
    ]
   },
@@ -326,9 +337,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/slate-demo.ipynb
+++ b/examples/slate-demo.ipynb
@@ -21,22 +21,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import print_function, division, absolute_import"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Imports for firefly_client"
    ]
   },
@@ -53,9 +37,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example uses http://127.0.0.1:8080/firefly as the server.\n",
+    "This example uses the IRSA Viewer application (https://irsa.ipac.caltech.edu) as the server.\n",
     "\n",
-    "'slate.html' is a template made for grid view "
+    "'slate.html' is a template made for grid view."
    ]
   },
   {
@@ -64,10 +48,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='http://127.0.0.1:8080/firefly'\n",
+    "url='https://irsa.ipac.caltech.edu/irsaviewer/'\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient(url, html_file=html)"
+    "fc = FireflyClient.make_client(url)"
    ]
   },
   {
@@ -291,9 +275,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/slate-demo.ipynb
+++ b/examples/slate-demo.ipynb
@@ -37,9 +37,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example uses the IRSA Viewer application (https://irsa.ipac.caltech.edu) as the server.\n",
+    "This example uses http://127.0.0.1:8080/firefly as the server, and 'slate.html' as the html file which is a template made for grid view.\n",
     "\n",
-    "'slate.html' is a template made for grid view."
+    "Both of these are passed by default if there are no corresponding environment variables set, but we're still passing them explicitly for clarity."
    ]
   },
   {
@@ -48,10 +48,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='https://irsa.ipac.caltech.edu/irsaviewer/'\n",
+    "url='http://127.0.0.1:8080/firefly'  # you can also use public server: https://irsa.ipac.caltech.edu/irsaviewer/\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient.make_client(url)"
+    "fc = FireflyClient.make_client(url, html_file=html)"
    ]
   },
   {
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a browser to the firefly server in a new tab. The browser open only works when running the notebook locally, otherwise the browser url will be displayed."
+    "Instantiating FireflyClient should open a browser to the firefly server in a new tab. You can also achieve this using the following method. The browser open only works when running the notebook locally, otherwise a link is displayed."
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "localbrowser, browser_url = fc.launch_browser()"
+    "# localbrowser, browser_url = fc.launch_browser()"
    ]
   },
   {
@@ -275,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/slate_hips_test.ipynb
+++ b/examples/slate_hips_test.ipynb
@@ -20,23 +20,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import print_function, division, absolute_import\n",
-    "import json"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Imports for firefly_client"
    ]
   },
@@ -47,6 +30,13 @@
    "outputs": [],
    "source": [
     "from firefly_client import FireflyClient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Settings for a WISE image for M81 at a selected band in HiPS format:"
    ]
   },
   {
@@ -76,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we use the slate.html application for a local server."
+    "In this example we use the slate.html template while the IRSA Viewer application acts as the server."
    ]
   },
   {
@@ -85,10 +75,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url='http://127.0.0.1:8080/firefly'\n",
+    "url='https://irsa.ipac.caltech.edu/irsaviewer/'\n",
     "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient(url, html_file=html)\n",
+    "fc = FireflyClient.make_client(url)\n",
     "fc.launch_browser()\n"
    ]
   },
@@ -153,6 +143,13 @@
    "metadata": {},
    "source": [
     "## Show HiP with hips to image conversion info"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show a HiPS converted to image"
    ]
   },
   {
@@ -296,9 +293,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/slate_hips_test.ipynb
+++ b/examples/slate_hips_test.ipynb
@@ -66,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example we use the slate.html template while the IRSA Viewer application acts as the server."
+    "In this example we use irsaviewer as firefly server (slate.html is the default template used)"
    ]
   },
   {
@@ -76,10 +76,8 @@
    "outputs": [],
    "source": [
     "url='https://irsa.ipac.caltech.edu/irsaviewer/'\n",
-    "html = 'slate.html'\n",
     "\n",
-    "fc = FireflyClient.make_client(url)\n",
-    "fc.launch_browser()\n"
+    "fc = FireflyClient.make_client(url)\n"
    ]
   },
   {
@@ -293,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -57,7 +57,7 @@ class FireflyClient:
         WebSocket channel ID. Default is None which auto-generates a unique string.
     html_file : `str`
         HTML file that is the 'landing page' for users, appended to the URL.
-        e.g. 'slate.html'. Defaults to None which is an empty string.
+        Defaults to 'slate.html'.
     make_default : `bool`
         If True, make this the default FireflyClient instance. Default False.
     use_lab_env : `bool`
@@ -148,7 +148,7 @@ class FireflyClient:
         html_file : `str`, optional
             HTML file that is the 'landing page' for users, appended to the URL.
             The default is the value of the environment variable 'FIREFLY_HTML'
-            if it is defined; otherwise None.
+            if it is defined; otherwise 'slate.html'.
         launch_browser : `bool`, optional
             If True, attempt to launch a browser tab for the Firefly viewer.
             If that attempt is unsuccessful, a link for the Firefly viewer is


### PR DESCRIPTION
Firefly-1185: Update server links and imports
- Edit URL for server to be IRSA Viewer and include Slate in all example notebooks
- Remove old imports for Python 2/3 compatibility