### PR TITLE
Update readme and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,19 @@ repository is located at http://github.com/Caltech-IPAC/firefly.
 Standalone Firefly servers may be obtained from
 [this Dockerhub repository](https://hub.docker.com/r/ipac/firefly/).
 
-For examples, see [the online documentation](https://firefly-client.lsst.io),
-or [the documentation source file](doc/index.rst).
-
+For detailed explanation on the usage, see [the online documentation](https://firefly-client.lsst.io),
+or [the documentation source file](doc/index.rst). Following is a very simple example:
 
 ```
 from firefly_client import FireflyClient
-fc = FireflyClient('http://localhost:8080')
+fc = FireflyClient.make_client()  # can also explictly pass url of a firefly server; default is http://localhost:8080/firefly
 ```
 
-A FITS image may be uploaded and displayed.
+A FITS image may be uploaded and displayed:
 
 ```
 fval = fc.upload_file('image.fits')
 fc.show_fits(fval, 'myimage')
 ```
+
+For more examples, check notebooks & python files in the [examples](examples/) and [test](test/) directories.

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -31,7 +31,7 @@ please start the Python session in the directory from which you downloaded the s
     :name: gs-start
 
     from firefly_client import FireflyClient
-    fc = FireflyClient('https://irsa.ipac.caltech.edu/irsaviewer')
+    fc = FireflyClient.make_client('https://irsa.ipac.caltech.edu/irsaviewer')
 
 Third, open a new browser tab using the :meth:`FireflyClient.launch_browser` method. If
 a browser cannot be opened, a URL will be displayed for your web browser.


### PR DESCRIPTION
firefly_client API seems to be updated since the documentation was written. 
- Replaced `FireflyClient()` which needs `url` as well as `channel` parameter, with `FireflyClient.make_client()` which is smarter 
- Updated readme to tell where to find examples

## Testing
- check https://github.com/Caltech-IPAC/firefly_client/tree/update-documentation#readme
- for sphinx documentation, someone has to rebuild https://firefly-client.lsst.io/