### PR TITLE
FIREFLY-1118: Fix errors in basic-demo notebook's methods

### DIFF
--- a/examples/basic-demo.ipynb
+++ b/examples/basic-demo.ipynb
@@ -183,9 +183,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#from IPython.display import IFrame\n",
-    "#print('url: %s' % fc.get_firefly_url())\n",
-    "#IFrame(fc.get_firefly_url(), 1100, 1000)"
+    "# from IPython.display import IFrame\n",
+    "# print('url: %s' % fc.get_firefly_url())\n",
+    "# IFrame(fc.get_firefly_url(), 1100, 1000)"
    ]
   },
   {
@@ -261,7 +261,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Zoom into the full image by a factor of 2 (note the `plot_id` parameter we used earlier):"
+    "Alternatively, more generic method show_chart() can be used to create the same plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# trace0 = {'tbl_id': 'tablemass', 'x': \"tables::j_m\", 'y': \"tables::h_m-k_m\", \n",
+    "#           'type' : 'scatter', 'mode': 'markers'}\n",
+    "# status = fc.show_chart(data=[trace0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Zoom into the full image by a factor of 2 (note the `plot_id` parameter we used earlier)"
    ]
   },
   {
@@ -351,7 +369,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -365,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -1316,7 +1316,7 @@ class FireflyClient:
         if coord.startswith('image'):
             payload.update({'centerOnImage': 'true'})
         elif x and y:
-            payload.update({'centerPt': {'x': x, 'y': y, 'type': 'WorldPt', 'cSys': coord}})
+            payload.update({'centerPt': f'{x};{y};{coord}'})
 
         return self.dispatch(ACTION_DICT['PanImage'], payload)
 

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -884,6 +884,10 @@ class FireflyClient:
                 Aspect ratio (must be between 1 and 10).
             **stretch** : {'fit', 'fill'}
                 Stretch method.
+            **plotStyle** : {'points', 'line', 'linepoints'}
+                Style of XY plot.
+            **chartTitle** : `str`
+                Title of the chart.
             **xLabel** : `str`
                 Label to use with x axis.
             **yLabel** : `str`
@@ -906,23 +910,6 @@ class FireflyClient:
                   parameters are valid.
         """
 
-        x_all = {'columnOrExpr': chart_params.get('xCol'), 'error': chart_params.get('xError'),
-                 'label': chart_params.get('xLabel'), 'unit': chart_params.get('xUnit'),
-                 'options': chart_params.get('xOptions')}
-        x = {k: v for k, v in x_all.items() if v}  # remove None values
-
-        y_all = {'columnOrExpr': chart_params.get('yCol'), 'error': chart_params.get('yError'),
-                 'label': chart_params.get('yLabel'), 'unit': chart_params.get('yUnit'),
-                 'options': chart_params.get('yOptions')}
-        y = {k: v for k, v in y_all.items() if v}  # remove None values
-
-        options_all = {'x': x, 'y': y, 'plotStyle': chart_params.get('plotStyle'),
-                       'sortColOrExpr': chart_params.get('sortColOrExpr'),
-                       'xyRatio': chart_params.get('xyRatio'), 'stretch': chart_params.get('stretch')}
-        options = {k: v for k, v in options_all.items() if v}  # remove None values
-
-        chart_data_elements = [{'type': 'xycols', 'options': options, 'tblId': tbl_id}]
-
         cid = gen_item_id('XYPlot')
 
         if not group_id:
@@ -930,7 +917,7 @@ class FireflyClient:
 
         payload = {'chartId': cid, 'chartType': 'scatter',
                    'groupId': group_id, 'viewerId': group_id,
-                   'chartDataElements': chart_data_elements}
+                   'params': {'tbl_id': tbl_id, **chart_params}}
 
         return self.dispatch(ACTION_DICT['ShowXYPlot'], payload)
 
@@ -970,33 +957,11 @@ class FireflyClient:
         .. note:: For the histogram parameters, `col` is required.
         """
 
-        chart_data_elements = {'type': 'histogram', 'tblId': tbl_id}
-
-        if 'col' in histogram_params:
-            options = {'columnOrExpr': histogram_params.get('col'),
-                       'x': histogram_params.get('xOptions', ''),
-                       'y': histogram_params.get('yOptions', '')}
-
-            if 'falsePositiveRate' in histogram_params:
-                options.update({'falsePositiveRate': histogram_params.get('falsePositiveRate')})
-                options.update({'algorithm': 'bayesianBlocks'})
-            else:
-                options.update({'algorithm': 'fixedSizeBins'})
-                if histogram_params.get('numBins', 0) > 0 or histogram_params.get('binWidth', 0) <= 0:
-                    num = histogram_params.get('numBins', 50)
-                    num = 50 if num <= 0 else num
-                    options.update({'fixedBinSizeSelection': histogram_params.get('fixedBinSizeSelection', 'numBins'),
-                                    'numBins': num})
-                else:
-                    options.update({'fixedBinSizeSelection': histogram_params.get('fixedBinSizeSelection', 'binWidth'),
-                                    'binWidth': histogram_params.get('binWidth')})
-            chart_data_elements.update({'options': options})
-
         cid = gen_item_id('Histogram')
         payload = {'chartId': cid, 'chartType': 'histogram',
                    'groupId': group_id,
                    'viewerId': group_id,
-                   'chartDataElements': [chart_data_elements]}
+                   'params': {'tbl_id': tbl_id, **histogram_params}}
 
         return self.dispatch(ACTION_DICT['ShowXYPlot'], payload)
 

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -1335,9 +1335,11 @@ class FireflyClient:
             ID of the plot to be panned. If plot_id is a list or tuple, then each plot in the list
             or the tuple is panned in order.
         x, y : `int` or  `float`, optional
-            New center of x and y position to scroll to.
-        coord : {'image', 'J2000'}, optional
-            Coordinate system (the default is 'image').
+            New center of x and y position to scroll to. Not required if coord is set 'image'
+            because it will center on the image.
+        coord : str, optional
+            Coordinate system to use if x and y is specified like J2000, EQB2000, GAL, etc.
+            The default is 'image' which will center on the image.
 
         Returns
         -------
@@ -1346,11 +1348,10 @@ class FireflyClient:
         """
 
         payload = {'plotId': plot_id}
-        if x and y:
-            if coord.startswith('image'):
-                payload.update({'centerPt': {'x': x, 'y': y, 'type': 'ImagePt'}})
-            else:
-                payload.update({'centerPt': {'x': x, 'y': y, 'type': 'J2000'}})
+        if coord.startswith('image'):
+            payload.update({'centerOnImage': 'true'})
+        elif x and y:
+            payload.update({'centerPt': {'x': x, 'y': y, 'type': 'WorldPt', 'cSys': coord}})
 
         return self.dispatch(ACTION_DICT['PanImage'], payload)
 
@@ -1467,7 +1468,7 @@ class FireflyClient:
             st_data.append({'band': band, 'rv': serialized_rv, 'bandVisible': True})
 
         payload = {'stretchData': st_data, 'plotId': plot_id}
-        return_val = self.dispatch_remote_action_by_post(self.channel, ACTION_DICT['StretchImage'], payload)
+        return_val = self.dispatch(ACTION_DICT['StretchImage'], payload)
         return_val['rv_lst'] = [d['rv'] for d in st_data]
         return return_val
 


### PR DESCRIPTION
Fixes [FIREFLY-1118](https://jira.ipac.caltech.edu/browse/FIREFLY-1118)

Made following changes in these 3 methods - mostly fixing outdated API:
1. `show_xyplot` (and `show_histogram`)
   - params field is expected in payload
   - cleaned up a lot of code since ff web client does that already in action creator
   - also added some missing but available chart_params in docstring
   - indicated in notebook that more generic `show_chart` can be used too (since `show_xyplot` calls deprecated function at web client as mentioned by @tgoldina in the ticket)
2. `set_pan`
   - `WorldPt` is expected for non-image case in payload, This needed change in existing FF code for recenter action creation as well - created PR https://github.com/Caltech-IPAC/firefly/pull/1424
   - allowed to pass any coordinate system for world point 
   - also improved logic of choosing `image` case over world point as well as payload expected for image 
3. `set_stretch_hprgb`
   - replaced outdated `dispatch_remote_action_by_post` method with `dispatch`


## Testing
Pull this branch locally, re-install firefly_client package to access updated code (no need if installed in development mode), and then re-run `basic-demo.ipynb`. When instantiating FireflyClient, make sure to set `url='https://fireflydev.ipac.caltech.edu/firefly-1118-fix-methods/firefly'` because of the changes at firefly repo. All of the above methods should work as expected.

