### PR TITLE
FIREFLY-1169: Add method for changing color

### DIFF
--- a/examples/basic-demo.ipynb
+++ b/examples/basic-demo.ipynb
@@ -327,6 +327,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Change color of the image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "status = fc.set_color('wise-fullimage', image_type='fits', colormap_id=6, bias=0.6, contrast=1.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Add region data to the cutout image (2 areas to begin with):"
    ]
   },

--- a/examples/basic-demo.ipynb
+++ b/examples/basic-demo.ipynb
@@ -336,7 +336,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "status = fc.set_color('wise-fullimage', image_type='fits', colormap_id=6, bias=0.6, contrast=1.5)"
+    "status = fc.set_color('wise-fullimage', colormap_id=6, bias=0.6, contrast=1.5)"
    ]
   },
   {

--- a/examples/basic_3color.ipynb
+++ b/examples/basic_3color.ipynb
@@ -87,6 +87,26 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "# Set contrast and bias for each band\n",
+    "fc.set_color(plot_id='wise_m101', image_type='fits_3color', bias=[0.4, 0.6, 0.5], contrast=[1.5, 1, 2]) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set to use red and blue band only\n",
+    "fc.set_color(plot_id='wise_m101', image_type='fits_3color', use_rgb_bands=[True, False, True]) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/examples/basic_3color.ipynb
+++ b/examples/basic_3color.ipynb
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "# Set contrast and bias for each band\n",
-    "fc.set_color(plot_id='wise_m101', image_type='fits_3color', bias=[0.4, 0.6, 0.5], contrast=[1.5, 1, 2]) "
+    "fc.set_rgb_colors(plot_id='wise_m101', bias=[0.4, 0.6, 0.5], contrast=[1.5, 1, 2]) "
    ]
   },
   {
@@ -98,8 +98,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set to use red and blue band only\n",
-    "fc.set_color(plot_id='wise_m101', image_type='fits_3color', use_rgb_bands=[True, False, True]) "
+    "# Set to use red and blue band only, with default bias and contrast\n",
+    "fc.set_rgb_colors(plot_id='wise_m101', use_green=False) "
    ]
   },
   {

--- a/examples/slate_hips_test.ipynb
+++ b/examples/slate_hips_test.ipynb
@@ -130,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fc.set_color('aHipsID1-1', 'hips', colormap_id=6, contrast=1.5)"
+    "fc.set_color('aHipsID1-1', colormap_id=6, bias=0.6, contrast=1.5)"
    ]
   },
   {

--- a/examples/slate_hips_test.ipynb
+++ b/examples/slate_hips_test.ipynb
@@ -121,6 +121,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Change color attributes in this image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc.set_color('aHipsID1-1', 'hips', colormap_id=6, contrast=1.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Show another HiPS in the same viewer"
    ]
   },

--- a/firefly_client/fc_utils.py
+++ b/firefly_client/fc_utils.py
@@ -75,6 +75,7 @@ ACTION_DICT = {
     'ZoomImage': 'ImagePlotCntlr.ZoomImage',
     'PanImage': 'ImagePlotCntlr.recenter',
     'StretchImage': 'ImagePlotCntlr.StretchChange',
+    'ColorImage': 'ImagePlotCntlr.ColorChange',
     'CreateRegionLayer': 'DrawLayerCntlr.RegionPlot.createLayer',
     'DeleteRegionLayer': 'DrawLayerCntlr.RegionPlot.deleteLayer',
     'AddRegionData': 'DrawLayerCntlr.RegionPlot.addRegion',

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -1437,59 +1437,70 @@ class FireflyClient:
         return_val['rv_lst'] = [d['rv'] for d in st_data]
         return return_val
 
-    def set_color(self, plot_id, image_type, **color_params):
+    def set_color(self, plot_id, colormap_id=0, bias=.5, contrast=1):
         """
-        Change the color attributes (color bar, bias, constrast) of an image plot.
+        Change the color attributes (color map, bias, constrast) of an image plot.
 
         Parameters
         ----------
         plot_id : `str` or `list` of `str`
             ID of the image plot to be colored.
-        image_type : {'fits', 'fits_3color', 'hips'}
-            Type of the image plot.
-        **color_params : optional keyword arguments
-            Parameters for changing the color. The options are shown as below:
-
-            **colormap_id** : `int`, optional
-                ID of the colormap or color-table to use, ranging from 0 to 21.
-                For 'fits', the default is 0 (grayscale). For 'hips', the default is -1
-                (default colormap of image). For 'fits_3color', this parameter isn't used.
-                Refer to the color dropdown on the image toolbar to see how IDs are mapped.
-            **bias** : `float` or `list` of `float`, optional
-                Bias to use, between 0 and 1 (the default is 0.5 for 'fits' and 'hips',
-                and [0.5, 0.5, 0.5] for 'fits_3color')
-            **contrast** : `float` or `list` of `float`, optional
-                Contrast to use, between 0 and 10 (the default is 1 for 'fits' and 'hips',
-                and [1, 1, 1] for 'fits_3color')
-            **use_rgb_bands** : `list` of `bool`, optional
-                Whether to use red, green, and blue band in coloring the image
-                (the default is [True, True, True]). This parameter is only used
-                for 'fits_3color'.
+        colormap_id : `int`, optional
+            ID of the colormap or color-table to use, ranging from 0 to 21.
+            (the default is 0 i.e. grayscale). For HiPS image, -1 can be used
+            to set the default hips image colors.
+            Refer to the color dropdown on the image toolbar to see how IDs are mapped.
+        bias : `float`, optional
+            Bias to use, between 0 and 1 (the default is 0.5)
+        contrast : `float`, optional
+            Contrast to use, between 0 and 10 (the default is 1)
 
         Returns
         -------
         out : `dict`
             Status of the request, like {'success': True}.
 
-        .. note:: when `colormap_id` is -1 for 'hips', `contrast` and `bias` have no effect.
+        .. note:: when `colormap_id` is -1 for HiPS image, `contrast` and `bias` have no effect.
         """
-        payload = {'plotId': plot_id}
-        
-        if image_type not in ['fits', 'fits_3color', 'hips']:
-            raise ValueError('Invalid image_type, only "fits", "fits_3color", or "hips" is allowed.')
-        
-        if 'colormap_id' in color_params and color_params['colormap_id'] is not None:
-            payload['cbarId'] = color_params['colormap_id']
-        else:  # otherwise firefly won't be able to handle undefined values
-            payload['cbarId'] = -1 if image_type=='hips' else 0
+        payload = {'plotId': plot_id,
+                   'cbarId': colormap_id,
+                   'bias': bias,
+                   'contrast': contrast
+                   }        
+        return self.dispatch(ACTION_DICT['ColorImage'], payload)
+    
+    def set_rgb_colors(self, plot_id, use_red=True, use_green=True, use_blue=True,
+                       bias=[.5,.5,.5], contrast=[1,1,1]):
+        """
+        Change the color attributes of a 3-color fits image plot.
 
-        if 'use_rgb_bands' in color_params and image_type=='fits_3color' and len(color_params['use_rgb_bands']) == 3:
-            payload['useRed'], payload['useGreen'], payload['useBlue'] = color_params['use_rgb_bands']
+        Parameters
+        ----------
+        plot_id : `str` or `list` of `str`
+            ID of the image plot to be colored.
+        use_red : `bool`, optional
+            Whether to use red band in coloring the image (default is True)
+        use_green : `bool`, optional
+            Whether to use green band in coloring the image (default is True)
+        use_blue : `bool`, optional
+            Whether to use blue band in coloring the image (default is True)
+        bias : `list` of `float`, optional
+            Bias to use for each band, between 0 and 1 (the default is [0.5, 0.5, 0.5])
+        contrast : `list` of `float`, optional
+            Contrast to use for each band, between 0 and 10 (the default is [1, 1, 1])
 
-        # firefly is able to handle invalid bias and contrast values for any image type
-        # so they can be added to payload without validation of type and values
-        payload.update({k: v for k, v in color_params.items() if v is not None and k in {'bias', 'contrast'}})
-        
+        Returns
+        -------
+        out : `dict`
+            Status of the request, like {'success': True}.
+        """
+        payload = {'plotId': plot_id, 
+                   'useRed': use_red,
+                   'useGreen': use_green,
+                   'useBlue': use_blue,
+                   'bias': bias,
+                   'contrast': contrast
+                   }
         return self.dispatch(ACTION_DICT['ColorImage'], payload)
 
     @staticmethod


### PR DESCRIPTION
Fixes [FIREFLY-1169](https://jira.ipac.caltech.edu/browse/FIREFLY-1169) by adding a new method `set_color()`.

Color changing at firefly not only deals with colormaps but also deals with bias and contrast  so this method allows changing them as well. Also the value of these params depend on 3 cases - hips, fits, and fits in 3 color, so it also handes that. Read docstring of this method for more context.

## Testing 
Checkout this branch locally and make sure you have firefly_client package installed in development mode to access the updated code.

Go to the change in each notebook and make sure running those cells update color in corresponding image (there are changes in 3 notebooks for each image type - click on purple-colored ReviewNB button below to see the diff)