### PR TITLE
FIREFLY-1623: Improve python API for tables

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -4,5 +4,4 @@ API reference
 
 .. automodapi:: firefly_client
    :no-inheritance-diagram:
-   :no-heading:
-
+   :skip: PackageNotFoundError, Env, FFWs, RangeValues

--- a/docs/usage/displaying-images.rst
+++ b/docs/usage/displaying-images.rst
@@ -221,3 +221,15 @@ It is possible to create a 3-color composite image using a list of dictionaries 
     fc.show_fits_3color(threeC,
     plot_id='wise_m101',
     viewer_id='3C')
+
+
+Displaying Image from a URL
+---------------------------
+
+If you have the URL of an image, you can pass it directly instead of 
+downloading it and then uploading it to firefly:
+
+.. code-block:: py
+
+    image_url = 'http://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a/149/02206a149-w1-int-1b.fits?center=70,20&size=200pix'
+    fc.show_fits(url=image_url, plot_id='wise-allsky', title='WISE all-sky')

--- a/docs/usage/viewing-tables.rst
+++ b/docs/usage/viewing-tables.rst
@@ -22,7 +22,7 @@ without showing the table in the viewer, use :meth:`FireflyClient.fetch_table`:
 
     fc.fetch_table(file_on_server=tval, tbl_id='invisible-table')
 
-Alternatively, you can turn off the `visible` parameter in :meth:`FireflyClient.fetch_table`:
+Alternatively, you can turn off the `visible` parameter in :meth:`FireflyClient.show_table`:
 
 .. code-block:: py
 
@@ -67,3 +67,5 @@ order:
 .. code-block:: py
     
     fc.sort_table_column(tbl_id=tbl_id_2mass_psc, column_name='j_m', sort_direction='ASC')
+
+If a column has sorting, it can be removed by specifying `sort_direction=''`.

--- a/docs/usage/viewing-tables.rst
+++ b/docs/usage/viewing-tables.rst
@@ -1,5 +1,6 @@
+###############################
 Visualizing Tables and Catalogs
--------------------------------
+###############################
 
 Tables can be uploaded to the Firefly server with :meth:`FireflyClient.upload_file`,
 and displayed in a table viewer component with :meth:`FireflyClient.show_table`.
@@ -11,6 +12,9 @@ if the table contains recognizable celestial coordinates.
     tval = fc.upload_file('m31-2mass-2412-row.tbl')
     fc.show_table(file_on_server=tval, tbl_id='m31-table')
 
+Modifying Table Display Parameters
+----------------------------------
+
 If it is desired to overlay the table on an image, or to make plots from it,
 without showing the table in the viewer, use :meth:`FireflyClient.fetch_table`:
 
@@ -18,13 +22,24 @@ without showing the table in the viewer, use :meth:`FireflyClient.fetch_table`:
 
     fc.fetch_table(file_on_server=tval, tbl_id='invisible-table')
 
+Alternatively, you can turn off the `visible` parameter in :meth:`FireflyClient.fetch_table`:
+
+.. code-block:: py
+
+    fc.show_table(file_on_server=tval, tbl_id='invisible-table', visible=False)
+
 If the table does not contain celestial coordinates recognized by Firefly,
-the image overlay will not appear. BUt if you specifically do not want
-the table overlaid on the image, `is_catalog=False` can be specified:
+the image overlay will not appear. But if you specifically do not want
+the table overlaid on the image, `is_catalog=False` can be specified (it is 
+`True` by default):
 
 .. code-block:: py
 
     fc.show_table(file_on_server=tval, tbl_id='2mass-tbl', is_catalog=False)
+
+
+Displaying Table from a URL
+---------------------------
 
 If you have the URL of a table, you can pass it directly instead of 
 downloading it and then uploading it to firefly:
@@ -32,4 +47,23 @@ downloading it and then uploading it to firefly:
 .. code-block:: py
 
     table_url = "http://irsa.ipac.caltech.edu/TAP/sync?FORMAT=IPAC_TABLE&QUERY=SELECT+*+FROM+fp_psc+WHERE+CONTAINS(POINT('J2000',ra,dec),CIRCLE('J2000',70.0,20.0,0.1))=1"
-    fc.show_table(url=table_url, tbl_id='2mass-point-source-catalog')
+    tbl_id_2mass_psc = '2mass-point-source-catalog'
+    fc.show_table(url=table_url, tbl_id=tbl_id_2mass_psc)
+
+Filtering/Sorting a loaded Table
+--------------------------------
+
+After displaying a table in firefly, you can also apply filters on it. 
+You will need to pass the `tbl_id` of that table and specify `filters` as an
+SQL WHERE clause-like string with column names quoted:
+
+.. code-block:: py
+    
+    fc.apply_table_filters(tbl_id=tbl_id_2mass_psc, filters='"j_m">15 and "j_m"<16 and "j_cmsig"<0.06')
+
+You can sort the table by a column in ascending (`ASC`) or descending (`DESC`)
+order:
+
+.. code-block:: py
+    
+    fc.sort_table_column(tbl_id=tbl_id_2mass_psc, column_name='j_m', sort_direction='ASC')

--- a/docs/usage/viewing-tables.rst
+++ b/docs/usage/viewing-tables.rst
@@ -26,3 +26,10 @@ the table overlaid on the image, `is_catalog=False` can be specified:
 
     fc.show_table(file_on_server=tval, tbl_id='2mass-tbl', is_catalog=False)
 
+If you have the URL of a table, you can pass it directly instead of 
+downloading it and then uploading it to firefly:
+
+.. code-block:: py
+
+    table_url = "http://irsa.ipac.caltech.edu/TAP/sync?FORMAT=IPAC_TABLE&QUERY=SELECT+*+FROM+fp_psc+WHERE+CONTAINS(POINT('J2000',ra,dec),CIRCLE('J2000',70.0,20.0,0.1))=1"
+    fc.show_table(url=table_url, tbl_id='2mass-point-source-catalog')

--- a/firefly_client/fc_utils.py
+++ b/firefly_client/fc_utils.py
@@ -70,6 +70,8 @@ ACTION_DICT = {
     'AddExtension': 'ExternalAccessCntlr/extensionAdd',
     'FetchTable': 'table.fetch',
     'ShowTable': 'table.search',
+    'TableFilter': 'table.filter',
+    'TableSort': 'table.sort',
     'ShowXYPlot': 'charts.data/chartAdd',
     'ShowPlot': 'charts.data/chartAdd',
     'ZoomImage': 'ImagePlotCntlr.ZoomImage',

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -1952,8 +1952,8 @@ class FireflyClient:
         column_name : `str`
             Name of the table column to sort
         sort_direction : {'', 'ASC', 'DESC'}, optional
-            Direction of sort: '' for unsorted, 'ASC' for ascending, and 'DESC'
-            for descending. Default is ''.
+            Direction of sort: '' for unsorted (or for removing the sort), 
+            'ASC' for ascending, and 'DESC' for descending. Default is ''.
 
         Returns
         --------

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -1915,3 +1915,55 @@ class FireflyClient:
 
         payload = {'plotId': plot_id, 'imageOverlayId': mask_id}
         return self.dispatch(ACTION_DICT['DeleteOverlayMask'], payload)
+
+    # ----------------------------
+    # actions on table
+    # ----------------------------
+
+    def apply_table_filters(self, tbl_id, filters):
+        """
+        Apply filters to a loaded table.
+
+        Parameters
+        ----------
+        plot_id : `str`
+            ID of the table where you want to apply filters
+        filters : `str`
+            SQL WHERE clause-like string specifying filters. Column names must be quoted.
+            For e.g. '("ra" > 185 AND "ra" < 185.1) OR ("dec" > 15 AND "dec" < 15.1) AND "band" IN (1,2)'.
+
+        Returns
+        --------
+        out : `dict`
+            Status of the request, like {'success': True}
+        """
+        tbl_req = {'tbl_id': tbl_id, 'filters': filters}
+        payload = {'request': tbl_req}
+        return self.dispatch(ACTION_DICT['TableFilter'], payload)
+    
+    def sort_table_column(self, tbl_id, column_name, sort_direction=''):
+        """
+        Sort a loaded table by a given column name.
+
+        Parameters
+        ----------
+        plot_id : `str`
+            ID of the table where you want to apply sort
+        column_name : `str`
+            Name of the table column to sort
+        sort_direction : {'', 'ASC', 'DESC'}, optional
+            Direction of sort: '' for unsorted, 'ASC' for ascending, and 'DESC'
+            for descending. Default is ''.
+
+        Returns
+        --------
+        out : `dict`
+            Status of the request, like {'success': True}
+        """
+        sort_directions = ['', 'ASC', 'DESC']
+        if sort_direction not in sort_directions:
+            raise ValueError(f'Invalid sort_direction. Valid values are {sort_directions}')
+        
+        tbl_req = {'tbl_id': tbl_id, 'sortInfo': f'{sort_direction},{column_name}'}
+        payload = {'request': tbl_req}
+        return self.dispatch(ACTION_DICT['TableSort'], payload)


### PR DESCRIPTION
Fixes [FIREFLY-1623](https://jira.ipac.caltech.edu/browse/FIREFLY-1623)

- Added `url` param to `show_table()` that can be used instead of `file_on_server` or `target_search_info` - this is similar to `show_fits()` which accepts `url` param as part of additonal params
- Documented usage of `url` param for both table and image
- Created two methods for sorting/filtering a loaded table, with documentation 

Bonus: removed internal classes from API reference because they are of no use to end-user and were causing confusion

Note: I wanted to create a 3rd method to set UI options too but it's more complicated so I deferred it to [FIREFLY-1631](https://jira.ipac.caltech.edu/browse/FIREFLY-1631) in the interest of time


## Testing
Copy the method examples (added in rst docs) in your notebook with firefly_client installed, they should work