### PR TITLE
Upgrade python dependency to >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "firefly_client"
-version = "3.2.0"
+version = "3.3.0"
 description = "Python API for Firefly: display astronomical data as tables, images, charts, and more!"
 authors = [
     {name = "IPAC LSST SUIT"}
 ]
 readme = "README.md"
 license = {file = "License.txt"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "websocket-client",
     "requests"


### PR DESCRIPTION
To maintain compatibility with upcoming CLI functionality by @annie444, we need to upgrade python dependency. I'll make a release once we merge this.

Also see: https://github.com/Caltech-IPAC/jupyter_firefly_extensions/pull/39

## Testing
Pull this branch locally. Setup a new env with latest python (or atleast python 3.10) and then development install firefly-client:
```bash
conda create -n ff-py310 python jupyter
conda activate ff-py310
pip install -e .[docs]
jupyter notebook
```
Run any examples/ notebook it should work as before