### PR TITLE
FIREFLY-1705: Add a static method to determine firefly access & better error handling

### DIFF
--- a/examples/test-access.ipynb
+++ b/examples/test-access.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "befc8619",
    "metadata": {},
    "outputs": [],
@@ -21,18 +21,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "cf4a4e98",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Uncomment for debugging outputs\n",
-    "FireflyClient._debug= True"
+    "# FireflyClient._debug= True"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "38803c9f",
    "metadata": {},
    "outputs": [],
@@ -42,49 +42,73 @@
   },
   {
    "cell_type": "markdown",
-   "id": "694e0a44",
+   "id": "6c665c34",
    "metadata": {},
    "source": [
-    "> Note: If you are using a JupyterLab environment, i.e. `using_lab=True`, setting `url` in the following cells will not work since it picks Firefly URL from the environment variable `FIREFLY_URL` or jupyter config files (~/.jupyter/jupyter_notebook_config.json or ~/.jupyter/jupyter_notebook_config.py)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3e1bd53b",
-   "metadata": {},
-   "source": [
-    "## Public firefly server"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d3a556ba",
-   "metadata": {},
-   "source": [
-    "### Valid url"
+    "## Firefly server URL setup"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "c639ff2a",
+   "execution_count": null,
+   "id": "a4755749",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Ignored if using_lab=True, must set in environment variable or jupyter config files\n",
-    "url = 'https://irsa.ipac.caltech.edu/irsaviewer'"
+    "# Following only matters if using_lab=False. \n",
+    "TEST_URL = {\n",
+    "    'no-auth': 'https://irsa.ipac.caltech.edu/irsaviewer', # IRSAViewer\n",
+    "    'invalid': 'https://irsa.ipac.caltech.edu/irsaviewerxx', # IRSAViewer with typo\n",
+    "    'auth': 'https://data-int.lsst.cloud/portal/app/' # LSST Data Int Portal\n",
+    "}\n",
+    "\n",
+    "url = TEST_URL['auth']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bc7498e",
+   "metadata": {},
+   "source": [
+    "> ***IMPORTANT: If `using_lab=True`, one of the above test urls must be set in environment before starting the JupyterLab.***\n",
+    "\n",
+    "This will work out of the box on a science platform like RSP notebook aspect, where both url (and token if needed) are set in the environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d07c1bf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if using_lab: # since `url` is ignored in lab environment\n",
+    "    # url comes from jupyter-firefly-extensions (set as 'fireflyURLLab'), \n",
+    "    # which picks it from (in descending order of precedence):\n",
+    "    # - environment variable 'FIREFLY_URL' \n",
+    "    # - ~/.jupyter/jupyter_notebook_config.json\n",
+    "    # - ~/.jupyter/jupyter_notebook_config.py\n",
+    "    url = os.environ['fireflyURLLab']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b78e3342",
+   "metadata": {},
+   "source": [
+    "## No token"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e604f548",
+   "id": "541d96b2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'success': True, 'response': <Response [200]>}"
+       "{'success': False, 'response': <Response [302]>}"
       ]
      },
      "execution_count": 6,
@@ -99,172 +123,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "833bce4f",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEBUG: new instance: https://irsa.ipac.caltech.edu/irsaviewer\n"
-     ]
-    }
-   ],
-   "source": [
-    "fc = FireflyClient.make_lab_client() if using_lab else FireflyClient.make_client(url)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "85a49c83",
-   "metadata": {},
-   "source": [
-    "### Invalid url"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "a631ca34",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Ignored if using_lab=True, must set in environment variable or jupyter config files\n",
-    "url += 'xx'  # Invalid URL for testing"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "406dddd8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'success': False, 'response': <Response [404]>}"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "FireflyClient.confirm_access(url)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "758eeffd",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEBUG: Failed to access url: https://irsa.ipac.caltech.edu/irsaviewerxx, with token: None\n",
-      "Response status: 404 (Not Found)\n",
-      "Response headers: \"{'Date': 'Wed, 09 Jul 2025 19:35:12 GMT', 'Server': 'Apache/2.4.10', 'Content-Length': '196', 'Keep-Alive': 'timeout=15, max=100', 'Connection': 'Keep-Alive', 'Content-Type': 'text/html; charset=iso-8859-1'}\"\n",
-      "Response text: <!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n",
-      "<html><head>\n",
-      "<title>404 Not Found</title>\n",
-      "</head><body>\n",
-      "<h1>Not Found</h1>\n",
-      "<p>The requested URL was not found on this server.</p>\n",
-      "</body></html>\n",
-      "\n"
-     ]
-    },
-    {
-     "ename": "ValueError",
-     "evalue": "Connection failed to URL https://irsa.ipac.caltech.edu/irsaviewerxx with status: 404\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nIf an authorization token is required to access the above URL, the `token` parameter must be passed.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m fc \u001b[38;5;241m=\u001b[39m \u001b[43mFireflyClient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_client\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:216\u001b[0m, in \u001b[0;36mFireflyClient.make_client\u001b[0;34m(cls, url, html_file, launch_browser, channel_override, verbose, token, viewer_override)\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[1;32m    169\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmake_client\u001b[39m(\u001b[38;5;28mcls\u001b[39m, url\u001b[38;5;241m=\u001b[39m_default_url, html_file\u001b[38;5;241m=\u001b[39m_def_html_file, launch_browser\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[1;32m    170\u001b[0m                 channel_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, verbose\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, token\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, viewer_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    171\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    172\u001b[0m \u001b[38;5;124;03m    Factory method to create a Firefly client in a plain Python, IPython, or\u001b[39;00m\n\u001b[1;32m    173\u001b[0m \u001b[38;5;124;03m    notebook session, and attempt to open a display.  If a display cannot be\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m        A FireflyClient that works in the lab environment\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 216\u001b[0m     fc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mcls\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mEnv\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresolve_client_channel\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchannel_override\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhtml_file\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mviewer_override\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    217\u001b[0m     verbose \u001b[38;5;129;01mand\u001b[39;00m Env\u001b[38;5;241m.\u001b[39mshow_start_browser_tab_msg(fc\u001b[38;5;241m.\u001b[39mget_firefly_url())\n\u001b[1;32m    218\u001b[0m     launch_browser \u001b[38;5;129;01mand\u001b[39;00m fc\u001b[38;5;241m.\u001b[39mlaunch_browser()\n",
-      "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:261\u001b[0m, in \u001b[0;36mFireflyClient.__init__\u001b[0;34m(self, url, channel, html_file, token, viewer_override)\u001b[0m\n\u001b[1;32m    253\u001b[0m     url_err_msg \u001b[38;5;241m=\u001b[39m Env\u001b[38;5;241m.\u001b[39mfailed_net_message(url, access[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mresponse\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mstatus_code)\n\u001b[1;32m    254\u001b[0m     token_err_msg \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    255\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mCheck if the passed `token` is valid and has the necessary \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    256\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mauthorization to access the above URL.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    259\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mthe `token` parameter must be passed.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    260\u001b[0m     )\n\u001b[0;32m--> 261\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mtoken_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    262\u001b[0m debug(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew instance: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n",
-      "\u001b[0;31mValueError\u001b[0m: Connection failed to URL https://irsa.ipac.caltech.edu/irsaviewerxx with status: 404\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nIf an authorization token is required to access the above URL, the `token` parameter must be passed."
-     ]
-    }
-   ],
-   "source": [
-    "fc = FireflyClient.make_client(url)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b78e3342",
-   "metadata": {},
-   "source": [
-    "## Firefly server behind authentication"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "d07c1bf2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "url = 'https://data-int.lsst.cloud/portal/app/' if not using_lab else os.environ['fireflyURLLab']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "07efe65f",
-   "metadata": {},
-   "source": [
-    "### No token"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "541d96b2",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'success': False, 'response': <Response [302]>}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "FireflyClient.confirm_access(url)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
    "id": "0f1916a8",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEBUG: Failed to access url: https://data-int.lsst.cloud/portal/app/, with token: None\n",
-      "Response status: 302 (Moved Temporarily)\n",
-      "Response headers: \"{'Date': 'Wed, 09 Jul 2025 19:35:23 GMT', 'Content-Type': 'text/html', 'Content-Length': '138', 'Connection': 'keep-alive', 'www-authenticate': 'Bearer realm=\\\"data-int.lsst.cloud\\\"', 'Location': 'https://data-int.lsst.cloud/login?rd=https://data-int.lsst.cloud%2Fportal%2Fapp%2Fhealthz'}\"\n",
-      "Response text: <html>\n",
-      "<head><title>302 Found</title></head>\n",
-      "<body>\n",
-      "<center><h1>302 Found</h1></center>\n",
-      "<hr><center>nginx</center>\n",
-      "</body>\n",
-      "</html>\n",
-      "\n"
-     ]
-    },
     {
      "ename": "ValueError",
      "evalue": "Connection failed to URL https://data-int.lsst.cloud/portal/app/ with status: 302\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nIf an authorization token is required to access the above URL, the `token` parameter must be passed.",
@@ -272,7 +133,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[13], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m fc \u001b[38;5;241m=\u001b[39m FireflyClient\u001b[38;5;241m.\u001b[39mmake_lab_client() \u001b[38;5;28;01mif\u001b[39;00m using_lab \u001b[38;5;28;01melse\u001b[39;00m \u001b[43mFireflyClient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_client\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m fc \u001b[38;5;241m=\u001b[39m FireflyClient\u001b[38;5;241m.\u001b[39mmake_lab_client() \u001b[38;5;28;01mif\u001b[39;00m using_lab \u001b[38;5;28;01melse\u001b[39;00m \u001b[43mFireflyClient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_client\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m)\u001b[49m\n",
       "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:216\u001b[0m, in \u001b[0;36mFireflyClient.make_client\u001b[0;34m(cls, url, html_file, launch_browser, channel_override, verbose, token, viewer_override)\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[1;32m    169\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmake_client\u001b[39m(\u001b[38;5;28mcls\u001b[39m, url\u001b[38;5;241m=\u001b[39m_default_url, html_file\u001b[38;5;241m=\u001b[39m_def_html_file, launch_browser\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[1;32m    170\u001b[0m                 channel_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, verbose\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, token\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, viewer_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    171\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    172\u001b[0m \u001b[38;5;124;03m    Factory method to create a Firefly client in a plain Python, IPython, or\u001b[39;00m\n\u001b[1;32m    173\u001b[0m \u001b[38;5;124;03m    notebook session, and attempt to open a display.  If a display cannot be\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m        A FireflyClient that works in the lab environment\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 216\u001b[0m     fc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mcls\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mEnv\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresolve_client_channel\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchannel_override\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhtml_file\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mviewer_override\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    217\u001b[0m     verbose \u001b[38;5;129;01mand\u001b[39;00m Env\u001b[38;5;241m.\u001b[39mshow_start_browser_tab_msg(fc\u001b[38;5;241m.\u001b[39mget_firefly_url())\n\u001b[1;32m    218\u001b[0m     launch_browser \u001b[38;5;129;01mand\u001b[39;00m fc\u001b[38;5;241m.\u001b[39mlaunch_browser()\n",
       "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:261\u001b[0m, in \u001b[0;36mFireflyClient.__init__\u001b[0;34m(self, url, channel, html_file, token, viewer_override)\u001b[0m\n\u001b[1;32m    253\u001b[0m     url_err_msg \u001b[38;5;241m=\u001b[39m Env\u001b[38;5;241m.\u001b[39mfailed_net_message(url, access[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mresponse\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mstatus_code)\n\u001b[1;32m    254\u001b[0m     token_err_msg \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    255\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mCheck if the passed `token` is valid and has the necessary \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    256\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mauthorization to access the above URL.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    259\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mthe `token` parameter must be passed.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    260\u001b[0m     )\n\u001b[0;32m--> 261\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mtoken_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    262\u001b[0m debug(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew instance: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n",
       "\u001b[0;31mValueError\u001b[0m: Connection failed to URL https://data-int.lsst.cloud/portal/app/ with status: 302\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nIf an authorization token is required to access the above URL, the `token` parameter must be passed."
@@ -288,12 +149,12 @@
    "id": "e38321cb",
    "metadata": {},
    "source": [
-    "### Invalid token"
+    "## Invalid token"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "aaa5ff12",
    "metadata": {},
    "outputs": [],
@@ -303,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "id": "4483f122",
    "metadata": {},
    "outputs": [
@@ -313,7 +174,7 @@
        "{'success': False, 'response': <Response [302]>}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,27 +185,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "id": "1f42031c",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEBUG: Failed to access url: https://data-int.lsst.cloud/portal/app/, with token: invalid_lsst_token\n",
-      "Response status: 302 (Moved Temporarily)\n",
-      "Response headers: \"{'Date': 'Wed, 09 Jul 2025 19:35:28 GMT', 'Content-Type': 'text/html', 'Content-Length': '138', 'Connection': 'keep-alive', 'www-authenticate': 'Bearer realm=\\\"data-int.lsst.cloud\\\", error=\\\"invalid_token\\\", error_description=\\\"Token does not start with gt-\\\"', 'Location': 'https://data-int.lsst.cloud/login?rd=https://data-int.lsst.cloud%2Fportal%2Fapp%2Fhealthz'}\"\n",
-      "Response text: <html>\n",
-      "<head><title>302 Found</title></head>\n",
-      "<body>\n",
-      "<center><h1>302 Found</h1></center>\n",
-      "<hr><center>nginx</center>\n",
-      "</body>\n",
-      "</html>\n",
-      "\n"
-     ]
-    },
     {
      "ename": "ValueError",
      "evalue": "Connection failed to URL https://data-int.lsst.cloud/portal/app/ with status: 302\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nCheck if the passed `token` is valid and has the necessary authorization to access the above URL.",
@@ -352,7 +196,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[16], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m fc \u001b[38;5;241m=\u001b[39m FireflyClient\u001b[38;5;241m.\u001b[39mmake_lab_client(token\u001b[38;5;241m=\u001b[39mtoken) \u001b[38;5;28;01mif\u001b[39;00m using_lab \u001b[38;5;28;01melse\u001b[39;00m \u001b[43mFireflyClient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_client\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtoken\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m fc \u001b[38;5;241m=\u001b[39m FireflyClient\u001b[38;5;241m.\u001b[39mmake_lab_client(token\u001b[38;5;241m=\u001b[39mtoken) \u001b[38;5;28;01mif\u001b[39;00m using_lab \u001b[38;5;28;01melse\u001b[39;00m \u001b[43mFireflyClient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_client\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtoken\u001b[49m\u001b[43m)\u001b[49m\n",
       "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:216\u001b[0m, in \u001b[0;36mFireflyClient.make_client\u001b[0;34m(cls, url, html_file, launch_browser, channel_override, verbose, token, viewer_override)\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[1;32m    169\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmake_client\u001b[39m(\u001b[38;5;28mcls\u001b[39m, url\u001b[38;5;241m=\u001b[39m_default_url, html_file\u001b[38;5;241m=\u001b[39m_def_html_file, launch_browser\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[1;32m    170\u001b[0m                 channel_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, verbose\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, token\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, viewer_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    171\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    172\u001b[0m \u001b[38;5;124;03m    Factory method to create a Firefly client in a plain Python, IPython, or\u001b[39;00m\n\u001b[1;32m    173\u001b[0m \u001b[38;5;124;03m    notebook session, and attempt to open a display.  If a display cannot be\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m        A FireflyClient that works in the lab environment\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 216\u001b[0m     fc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mcls\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mEnv\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresolve_client_channel\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchannel_override\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhtml_file\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mviewer_override\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    217\u001b[0m     verbose \u001b[38;5;129;01mand\u001b[39;00m Env\u001b[38;5;241m.\u001b[39mshow_start_browser_tab_msg(fc\u001b[38;5;241m.\u001b[39mget_firefly_url())\n\u001b[1;32m    218\u001b[0m     launch_browser \u001b[38;5;129;01mand\u001b[39;00m fc\u001b[38;5;241m.\u001b[39mlaunch_browser()\n",
       "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:261\u001b[0m, in \u001b[0;36mFireflyClient.__init__\u001b[0;34m(self, url, channel, html_file, token, viewer_override)\u001b[0m\n\u001b[1;32m    253\u001b[0m     url_err_msg \u001b[38;5;241m=\u001b[39m Env\u001b[38;5;241m.\u001b[39mfailed_net_message(url, access[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mresponse\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mstatus_code)\n\u001b[1;32m    254\u001b[0m     token_err_msg \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    255\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mCheck if the passed `token` is valid and has the necessary \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    256\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mauthorization to access the above URL.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    259\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mthe `token` parameter must be passed.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    260\u001b[0m     )\n\u001b[0;32m--> 261\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mtoken_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    262\u001b[0m debug(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew instance: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n",
       "\u001b[0;31mValueError\u001b[0m: Connection failed to URL https://data-int.lsst.cloud/portal/app/ with status: 302\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nCheck if the passed `token` is valid and has the necessary authorization to access the above URL."
@@ -368,7 +212,7 @@
    "id": "0478d21a",
    "metadata": {},
    "source": [
-    "### Valid token"
+    "## Valid token"
    ]
   },
   {
@@ -378,12 +222,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "token = os.environ['ACCESS_TOKEN'] # token must be set in environment (should work out of the box on RSP notebook aspect)"
+    "token = os.environ['ACCESS_TOKEN'] # token must be set in environment don't hardcode it here"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 13,
    "id": "d4e00c0f",
    "metadata": {},
    "outputs": [
@@ -393,7 +237,7 @@
        "{'success': True, 'response': <Response [200]>}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -404,18 +248,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 14,
    "id": "69730712",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEBUG: new instance: https://data-int.lsst.cloud/portal/app/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "fc = FireflyClient.make_lab_client(token=token) if using_lab else FireflyClient.make_client(url, token=token)"
    ]

--- a/examples/test-access.ipynb
+++ b/examples/test-access.ipynb
@@ -1,0 +1,453 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b89ca528-303e-45a8-abe9-7eb93b0b6825",
+   "metadata": {},
+   "source": [
+    "# Test accessing different Firefly servers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "befc8619",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cf4a4e98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment for debugging outputs\n",
+    "FireflyClient._debug= True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "38803c9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using_lab = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "694e0a44",
+   "metadata": {},
+   "source": [
+    "> Note: If you are using a JupyterLab environment, i.e. `using_lab=True`, setting `url` in the following cells will not work since it picks Firefly URL from the environment variable `FIREFLY_URL` or jupyter config files (~/.jupyter/jupyter_notebook_config.json or ~/.jupyter/jupyter_notebook_config.py)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e1bd53b",
+   "metadata": {},
+   "source": [
+    "## Public firefly server"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3a556ba",
+   "metadata": {},
+   "source": [
+    "### Valid url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c639ff2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ignored if using_lab=True, must set in environment variable or jupyter config files\n",
+    "url = 'https://irsa.ipac.caltech.edu/irsaviewer'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e604f548",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True, 'response': <Response [200]>}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "FireflyClient.confirm_access(url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "833bce4f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: new instance: https://irsa.ipac.caltech.edu/irsaviewer\n"
+     ]
+    }
+   ],
+   "source": [
+    "fc = FireflyClient.make_lab_client() if using_lab else FireflyClient.make_client(url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85a49c83",
+   "metadata": {},
+   "source": [
+    "### Invalid url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a631ca34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ignored if using_lab=True, must set in environment variable or jupyter config files\n",
+    "url += 'xx'  # Invalid URL for testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "406dddd8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': False, 'response': <Response [404]>}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "FireflyClient.confirm_access(url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "758eeffd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: Failed to access url: https://irsa.ipac.caltech.edu/irsaviewerxx, with token: None\n",
+      "Response status: 404 (Not Found)\n",
+      "Response headers: \"{'Date': 'Wed, 09 Jul 2025 19:35:12 GMT', 'Server': 'Apache/2.4.10', 'Content-Length': '196', 'Keep-Alive': 'timeout=15, max=100', 'Connection': 'Keep-Alive', 'Content-Type': 'text/html; charset=iso-8859-1'}\"\n",
+      "Response text: <!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n",
+      "<html><head>\n",
+      "<title>404 Not Found</title>\n",
+      "</head><body>\n",
+      "<h1>Not Found</h1>\n",
+      "<p>The requested URL was not found on this server.</p>\n",
+      "</body></html>\n",
+      "\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "Connection failed to URL https://irsa.ipac.caltech.edu/irsaviewerxx with status: 404\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nIf an authorization token is required to access the above URL, the `token` parameter must be passed.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m fc \u001b[38;5;241m=\u001b[39m \u001b[43mFireflyClient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_client\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:216\u001b[0m, in \u001b[0;36mFireflyClient.make_client\u001b[0;34m(cls, url, html_file, launch_browser, channel_override, verbose, token, viewer_override)\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[1;32m    169\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmake_client\u001b[39m(\u001b[38;5;28mcls\u001b[39m, url\u001b[38;5;241m=\u001b[39m_default_url, html_file\u001b[38;5;241m=\u001b[39m_def_html_file, launch_browser\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[1;32m    170\u001b[0m                 channel_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, verbose\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, token\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, viewer_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    171\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    172\u001b[0m \u001b[38;5;124;03m    Factory method to create a Firefly client in a plain Python, IPython, or\u001b[39;00m\n\u001b[1;32m    173\u001b[0m \u001b[38;5;124;03m    notebook session, and attempt to open a display.  If a display cannot be\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m        A FireflyClient that works in the lab environment\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 216\u001b[0m     fc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mcls\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mEnv\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresolve_client_channel\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchannel_override\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhtml_file\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mviewer_override\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    217\u001b[0m     verbose \u001b[38;5;129;01mand\u001b[39;00m Env\u001b[38;5;241m.\u001b[39mshow_start_browser_tab_msg(fc\u001b[38;5;241m.\u001b[39mget_firefly_url())\n\u001b[1;32m    218\u001b[0m     launch_browser \u001b[38;5;129;01mand\u001b[39;00m fc\u001b[38;5;241m.\u001b[39mlaunch_browser()\n",
+      "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:261\u001b[0m, in \u001b[0;36mFireflyClient.__init__\u001b[0;34m(self, url, channel, html_file, token, viewer_override)\u001b[0m\n\u001b[1;32m    253\u001b[0m     url_err_msg \u001b[38;5;241m=\u001b[39m Env\u001b[38;5;241m.\u001b[39mfailed_net_message(url, access[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mresponse\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mstatus_code)\n\u001b[1;32m    254\u001b[0m     token_err_msg \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    255\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mCheck if the passed `token` is valid and has the necessary \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    256\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mauthorization to access the above URL.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    259\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mthe `token` parameter must be passed.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    260\u001b[0m     )\n\u001b[0;32m--> 261\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mtoken_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    262\u001b[0m debug(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew instance: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n",
+      "\u001b[0;31mValueError\u001b[0m: Connection failed to URL https://irsa.ipac.caltech.edu/irsaviewerxx with status: 404\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nIf an authorization token is required to access the above URL, the `token` parameter must be passed."
+     ]
+    }
+   ],
+   "source": [
+    "fc = FireflyClient.make_client(url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b78e3342",
+   "metadata": {},
+   "source": [
+    "## Firefly server behind authentication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d07c1bf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://data-int.lsst.cloud/portal/app/' if not using_lab else os.environ['fireflyURLLab']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07efe65f",
+   "metadata": {},
+   "source": [
+    "### No token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "541d96b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': False, 'response': <Response [302]>}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "FireflyClient.confirm_access(url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0f1916a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: Failed to access url: https://data-int.lsst.cloud/portal/app/, with token: None\n",
+      "Response status: 302 (Moved Temporarily)\n",
+      "Response headers: \"{'Date': 'Wed, 09 Jul 2025 19:35:23 GMT', 'Content-Type': 'text/html', 'Content-Length': '138', 'Connection': 'keep-alive', 'www-authenticate': 'Bearer realm=\\\"data-int.lsst.cloud\\\"', 'Location': 'https://data-int.lsst.cloud/login?rd=https://data-int.lsst.cloud%2Fportal%2Fapp%2Fhealthz'}\"\n",
+      "Response text: <html>\n",
+      "<head><title>302 Found</title></head>\n",
+      "<body>\n",
+      "<center><h1>302 Found</h1></center>\n",
+      "<hr><center>nginx</center>\n",
+      "</body>\n",
+      "</html>\n",
+      "\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "Connection failed to URL https://data-int.lsst.cloud/portal/app/ with status: 302\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nIf an authorization token is required to access the above URL, the `token` parameter must be passed.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[13], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m fc \u001b[38;5;241m=\u001b[39m FireflyClient\u001b[38;5;241m.\u001b[39mmake_lab_client() \u001b[38;5;28;01mif\u001b[39;00m using_lab \u001b[38;5;28;01melse\u001b[39;00m \u001b[43mFireflyClient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_client\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:216\u001b[0m, in \u001b[0;36mFireflyClient.make_client\u001b[0;34m(cls, url, html_file, launch_browser, channel_override, verbose, token, viewer_override)\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[1;32m    169\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmake_client\u001b[39m(\u001b[38;5;28mcls\u001b[39m, url\u001b[38;5;241m=\u001b[39m_default_url, html_file\u001b[38;5;241m=\u001b[39m_def_html_file, launch_browser\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[1;32m    170\u001b[0m                 channel_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, verbose\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, token\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, viewer_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    171\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    172\u001b[0m \u001b[38;5;124;03m    Factory method to create a Firefly client in a plain Python, IPython, or\u001b[39;00m\n\u001b[1;32m    173\u001b[0m \u001b[38;5;124;03m    notebook session, and attempt to open a display.  If a display cannot be\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m        A FireflyClient that works in the lab environment\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 216\u001b[0m     fc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mcls\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mEnv\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresolve_client_channel\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchannel_override\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhtml_file\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mviewer_override\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    217\u001b[0m     verbose \u001b[38;5;129;01mand\u001b[39;00m Env\u001b[38;5;241m.\u001b[39mshow_start_browser_tab_msg(fc\u001b[38;5;241m.\u001b[39mget_firefly_url())\n\u001b[1;32m    218\u001b[0m     launch_browser \u001b[38;5;129;01mand\u001b[39;00m fc\u001b[38;5;241m.\u001b[39mlaunch_browser()\n",
+      "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:261\u001b[0m, in \u001b[0;36mFireflyClient.__init__\u001b[0;34m(self, url, channel, html_file, token, viewer_override)\u001b[0m\n\u001b[1;32m    253\u001b[0m     url_err_msg \u001b[38;5;241m=\u001b[39m Env\u001b[38;5;241m.\u001b[39mfailed_net_message(url, access[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mresponse\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mstatus_code)\n\u001b[1;32m    254\u001b[0m     token_err_msg \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    255\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mCheck if the passed `token` is valid and has the necessary \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    256\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mauthorization to access the above URL.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    259\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mthe `token` parameter must be passed.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    260\u001b[0m     )\n\u001b[0;32m--> 261\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mtoken_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    262\u001b[0m debug(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew instance: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n",
+      "\u001b[0;31mValueError\u001b[0m: Connection failed to URL https://data-int.lsst.cloud/portal/app/ with status: 302\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nIf an authorization token is required to access the above URL, the `token` parameter must be passed."
+     ]
+    }
+   ],
+   "source": [
+    "fc = FireflyClient.make_lab_client() if using_lab else FireflyClient.make_client(url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e38321cb",
+   "metadata": {},
+   "source": [
+    "### Invalid token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "aaa5ff12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token = 'invalid_lsst_token'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "4483f122",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': False, 'response': <Response [302]>}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "FireflyClient.confirm_access(url, token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "1f42031c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: Failed to access url: https://data-int.lsst.cloud/portal/app/, with token: invalid_lsst_token\n",
+      "Response status: 302 (Moved Temporarily)\n",
+      "Response headers: \"{'Date': 'Wed, 09 Jul 2025 19:35:28 GMT', 'Content-Type': 'text/html', 'Content-Length': '138', 'Connection': 'keep-alive', 'www-authenticate': 'Bearer realm=\\\"data-int.lsst.cloud\\\", error=\\\"invalid_token\\\", error_description=\\\"Token does not start with gt-\\\"', 'Location': 'https://data-int.lsst.cloud/login?rd=https://data-int.lsst.cloud%2Fportal%2Fapp%2Fhealthz'}\"\n",
+      "Response text: <html>\n",
+      "<head><title>302 Found</title></head>\n",
+      "<body>\n",
+      "<center><h1>302 Found</h1></center>\n",
+      "<hr><center>nginx</center>\n",
+      "</body>\n",
+      "</html>\n",
+      "\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "Connection failed to URL https://data-int.lsst.cloud/portal/app/ with status: 302\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nCheck if the passed `token` is valid and has the necessary authorization to access the above URL.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[16], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m fc \u001b[38;5;241m=\u001b[39m FireflyClient\u001b[38;5;241m.\u001b[39mmake_lab_client(token\u001b[38;5;241m=\u001b[39mtoken) \u001b[38;5;28;01mif\u001b[39;00m using_lab \u001b[38;5;28;01melse\u001b[39;00m \u001b[43mFireflyClient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_client\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtoken\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:216\u001b[0m, in \u001b[0;36mFireflyClient.make_client\u001b[0;34m(cls, url, html_file, launch_browser, channel_override, verbose, token, viewer_override)\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[1;32m    169\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmake_client\u001b[39m(\u001b[38;5;28mcls\u001b[39m, url\u001b[38;5;241m=\u001b[39m_default_url, html_file\u001b[38;5;241m=\u001b[39m_def_html_file, launch_browser\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[1;32m    170\u001b[0m                 channel_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, verbose\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, token\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, viewer_override\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    171\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    172\u001b[0m \u001b[38;5;124;03m    Factory method to create a Firefly client in a plain Python, IPython, or\u001b[39;00m\n\u001b[1;32m    173\u001b[0m \u001b[38;5;124;03m    notebook session, and attempt to open a display.  If a display cannot be\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m        A FireflyClient that works in the lab environment\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 216\u001b[0m     fc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mcls\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mEnv\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresolve_client_channel\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchannel_override\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhtml_file\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mviewer_override\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    217\u001b[0m     verbose \u001b[38;5;129;01mand\u001b[39;00m Env\u001b[38;5;241m.\u001b[39mshow_start_browser_tab_msg(fc\u001b[38;5;241m.\u001b[39mget_firefly_url())\n\u001b[1;32m    218\u001b[0m     launch_browser \u001b[38;5;129;01mand\u001b[39;00m fc\u001b[38;5;241m.\u001b[39mlaunch_browser()\n",
+      "File \u001b[0;32m~/dev/cm/firefly_client/firefly_client/firefly_client.py:261\u001b[0m, in \u001b[0;36mFireflyClient.__init__\u001b[0;34m(self, url, channel, html_file, token, viewer_override)\u001b[0m\n\u001b[1;32m    253\u001b[0m     url_err_msg \u001b[38;5;241m=\u001b[39m Env\u001b[38;5;241m.\u001b[39mfailed_net_message(url, access[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mresponse\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mstatus_code)\n\u001b[1;32m    254\u001b[0m     token_err_msg \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    255\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mCheck if the passed `token` is valid and has the necessary \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    256\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mauthorization to access the above URL.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    259\u001b[0m         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mthe `token` parameter must be passed.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    260\u001b[0m     )\n\u001b[0;32m--> 261\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mtoken_err_msg\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    262\u001b[0m debug(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew instance: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00murl\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n",
+      "\u001b[0;31mValueError\u001b[0m: Connection failed to URL https://data-int.lsst.cloud/portal/app/ with status: 302\nYou may want to check the URL with your web browser.\n\nCheck if the Firefly URL is correct, which is passed as a parameter.\n\nCheck if the passed `token` is valid and has the necessary authorization to access the above URL."
+     ]
+    }
+   ],
+   "source": [
+    "fc = FireflyClient.make_lab_client(token=token) if using_lab else FireflyClient.make_client(url, token=token)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0478d21a",
+   "metadata": {},
+   "source": [
+    "### Valid token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4e5d7ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token = os.environ['ACCESS_TOKEN'] # token must be set in environment (should work out of the box on RSP notebook aspect)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "d4e00c0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True, 'response': <Response [200]>}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "FireflyClient.confirm_access(url, token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "69730712",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: new instance: https://data-int.lsst.cloud/portal/app/\n"
+     ]
+    }
+   ],
+   "source": [
+    "fc = FireflyClient.make_lab_client(token=token) if using_lab else FireflyClient.make_client(url, token=token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85a3e941",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ffpy",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/firefly_client/env.py
+++ b/firefly_client/env.py
@@ -93,12 +93,20 @@ class Env:
 
     @classmethod
     def failed_net_message(cls, location, status_code=-1):
-        s_str = 'with status: %s' % status_code if (status_code > -1) else ''
-        check = 'You may want to check the URL with your web browser.\n'
-        err_message = 'Connection fail to URL %s %s\n%s' % (location, s_str, check)
-        if cls.firefly_lab_extension and cls.firefly_url_lab:
-            err_message += ('\nCheck the Firefly URL in ~/.jupyter/jupyter_notebook_config.py' +
-                            ' or ~/.jupyter/jupyter_notebook_config.json')
-        elif cls.firefly_url:
-            err_message += 'Check setting of FIREFLY_URL environment variable: %s' % cls.firefly_url
+        status_str = f'with status: {status_code}' if status_code > -1 else ''
+        check_msg = 'You may want to check the URL with your web browser.\n'
+        err_message = f'Connection failed to URL {location} {status_str}\n{check_msg}'
+        
+        # url sources in order of precedence
+        url_sources = []
+        if cls.firefly_url: # any environment
+            url_sources.append(f'environment variable "{ENV_FF_URL}"')
+        if cls.firefly_lab_extension and cls.firefly_url_lab: # lab environment
+            url_sources += [
+                '~/.jupyter/jupyter_notebook_config.json',
+                '~/.jupyter/jupyter_notebook_config.py',
+            ]
+        err_message += (f'\nCheck if the Firefly URL is correct, which is '
+                        f'passed as a parameter, or is set via {" or ".join(url_sources)}.')
+
         return err_message

--- a/firefly_client/env.py
+++ b/firefly_client/env.py
@@ -106,7 +106,7 @@ class Env:
                 '~/.jupyter/jupyter_notebook_config.json',
                 '~/.jupyter/jupyter_notebook_config.py',
             ]
+        url_sources_msg = f', or is set via {" or ".join(url_sources)}' if url_sources else ''
         err_message += (f'\nCheck if the Firefly URL is correct, which is '
-                        f'passed as a parameter, or is set via {" or ".join(url_sources)}.')
-
+                        f'passed as a parameter{url_sources_msg}.')
         return err_message

--- a/firefly_client/fc_utils.py
+++ b/firefly_client/fc_utils.py
@@ -64,8 +64,8 @@ def ensure3(val, name):
     return ret
 
 
-# actions from Firefly
 ACTION_DICT = {
+    # actions from Firefly JS
     'ShowFits': 'ImagePlotCntlr.PlotImage',
     'AddExtension': 'ExternalAccessCntlr/extensionAdd',
     'FetchTable': 'table.fetch',
@@ -95,6 +95,8 @@ ACTION_DICT = {
     'ShowHiPS': 'ImagePlotCntlr.PlotHiPS',
     'ShowImageOrHiPS': 'ImagePlotCntlr.plotHiPSOrImage',
     'ImagelineBasedFootprint': 'DrawLayerCntlr.ImageLineBasedFP.imagelineBasedFPCreate',
+
+    # actions from jupyter_firefly_extensions
     'StartLabWindow': 'StartLabWindow',
     'StartBrowserTab': 'StartBrowserTab'
 }

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -232,17 +232,34 @@ class FireflyClient:
         self.auth_headers = {'Authorization': 'Bearer {}'.format(token)} if token and ssl else None
         self.header_from_ws = {'FF-channel': channel}
         self.lab_env_tab_type = UNKNOWN
+
         # urls for cmd service and browser
         protocol = 'https' if ssl else 'http'
         self.url_cmd_service = urljoin('{}://{}/'.format(protocol, self.location), 'sticky/CmdSrv')
         self.url_browser = urljoin(urljoin('{}://{}/'.format(protocol, self.location), html_file), '?__wsch=')
         self.url_bw = self.url_browser  # keep around for backward compatibility
+
         self.session = requests.Session()
         token and ssl and self.session.headers.update(self.auth_headers)
         not ssl and token and warn('token ignored: should be None when url starts with http://')
         self.firefly_viewer = FireflyClient.get_viewer_mode(html_file,viewer_override)
-        FireflyClient.confirm_access(url, token)
-        debug('new instance: %s' % url)
+
+        access = FireflyClient.confirm_access(url, token)
+        if not access['success']:
+            debug(f'Failed to access url: {url}, with token: {token}\n'
+                  f'Response status: {access["response"].status_code} ({access["response"].reason})\n'
+                  f'Response headers: {dict_to_str(access["response"].headers)}\n'
+                  f'Response text: {access["response"].text}')
+            url_err_msg = Env.failed_net_message(url, access['response'].status_code)
+            token_err_msg = (
+                'Check if the passed `token` is valid and has the necessary '
+                'authorization to access the above URL.'
+                if token else
+                'If an authorization token is required to access the above URL, '
+                'the `token` parameter must be passed.'
+            )
+            raise ValueError(f'{url_err_msg}\n\n{token_err_msg}')
+        debug(f'new instance: {url}')
 
     def _lab_env_tab_start(self, tab_type, html_file):
         """start a tab in the lab environment, tab_type must be 'lab' or 'browser' """
@@ -276,17 +293,12 @@ class FireflyClient:
             return FireflyClient.SLATE_VIEWER if html_file == 'slate.html' else FireflyClient.TRIVIEW_VIEWER
         
     @staticmethod
-    def confirm_access(url, token):
+    def confirm_access(url, token=None):
         headers = {'Authorization': f'Bearer {token}'} if token else None
         healthz_url = url + ('healthz' if url.endswith('/') else '/healthz')
+        # disable redirects that may happen in the absence of a token
         response = requests.get(healthz_url, headers=headers, allow_redirects=False)
-        if response.status_code == 200:
-            return True
-        else:
-            raise ValueError(
-                f"Access to {url} failed with status code {response.status_code}.\n"
-                f"GET Headers: {response.headers}"
-            )
+        return {'success': response.status_code == 200, 'response': response}
 
     def _send_url_as_get(self, url):
         return self.call_response(self.session.get(url, headers=self.header_from_ws))


### PR DESCRIPTION
Fixes [FIREFLY-1705](https://jira.ipac.caltech.edu/browse/FIREFLY-1705)

- Added a `confirm_access` static method as per the ticket. This is called in instantiation to catch the errors early on.
- Bonus: updated error messages to be more helpful/relevant


## Testing
1. Open jupyter lab through RSP notebook aspect.
2. Open a Terminal and run following commands:
```bash
conda create -n ffpy python=3.11 ipykernel -y
conda activate ffpy
python -m ipykernel install --user --name=ffpy
pip install git+https://github.com/Caltech-IPAC/firefly_client@FIREFLY-1705-confirm-access jupyter-firefly-extensions
cd ~/WORK  # or wherever you want to download & run notebooks
curl https://raw.githubusercontent.com/Caltech-IPAC/firefly_client/refs/heads/FIREFLY-1705-confirm-access/examples/test-access.ipynb -o test-access.ipynb
```
3. Go to WORK/test-acces.ipynb in file browser in the sidebar and open the notebook. Update `using_lab` to `True` and uncomment debug mode if needed. 
4. Test the current issues with access errors by running the notebook with `LSST` as the kernel (selectable in top-right of notebook)
5. Make a copy of this notebook (from file browser) and test the updates in access errors by running the notebook with `ffpy` as kernel (the env that we created above). Compare this notebook's outputs with those in last step:
   - The errors should tell user about fixing the url and token as appropriate to each case, instead of throwing JSONDecode errors
   - The debug mode should log url, token if `confirm_access` failed

