### PR TITLE
FIREFLY-1573: Extend Firefly python's file (up)loading API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,12 @@
 # firefly_client
 
-Python API for Firefly, IPAC's Advanced Astronomy Web UI Framework
+Python API for [Firefly](http://github.com/Caltech-IPAC/firefly), IPAC's Advanced Astronomy Web UI Framework. This allows users to leverage Firefly in their Python notebooks for interactive exploration of astronomical data (images, catalogs, charts, regions, and more) with just a couple of lines of code.
 
-## Usage
 
-The client must be connected to a Firefly server. The Firefly
-repository is located at http://github.com/Caltech-IPAC/firefly.
-Standalone Firefly servers may be obtained from
-[this Dockerhub repository](https://hub.docker.com/r/ipac/firefly/).
+## Documentation
 
-For detailed explanation on the usage, see [the online documentation](https://caltech-ipac.github.io/firefly_client). Following is a very simple example:
+You can find the documentation at https://caltech-ipac.github.io/firefly_client.
 
-```
-from firefly_client import FireflyClient
-fc = FireflyClient.make_client()  # can also explictly pass url of a firefly server; default is http://localhost:8080/firefly
-```
+NOTE: Many parts of this documentation are a work in progress because the firefly_client API and its use cases evolved since it was written.
+Please report any issues or suggestions on the [GitHub issues](https://github.com/Caltech-IPAC/firefly_client/issues).
 
-A FITS image may be uploaded and displayed:
-
-```
-fval = fc.upload_file('image.fits')
-fc.show_fits(fval, 'myimage')
-```
-
-For more examples, check notebooks & python files in the [examples](examples/) and [test](test/) directories.

--- a/docs/usage/demo-notebooks.rst
+++ b/docs/usage/demo-notebooks.rst
@@ -6,21 +6,19 @@ Demo Notebooks
 Reference Guide
 -----------------
 
-For a high-level overview of the Firefly Python client API and important methods, refer to this `reference guide notebook`.
-
-.. _`reference guide notebook`:
-    https://nbviewer.org/github/Caltech-IPAC/firefly_client/tree/master/examples/reference-guide.ipynb.
+For a high-level overview of the Firefly Python client API and important methods, refer to this `reference guide notebook <https://nbviewer.org/github/Caltech-IPAC/firefly_client/tree/master/examples/reference-guide.ipynb>`_.
 
 
 Science Use-cases
 -----------------
 
 IRSA Tutorials is collection of multiple notebooks that demonstrate the use of IRSA data services and tools for science use-cases.
-The following notebook demonstrates the use of Firefly Python Client:
-- https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/SEDs_in_Firefly.html
-- https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/NEOWISE_light_curve_demo.html
-- https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/OpenUniverse2024Preview_Firefly.html
-- https://caltech-ipac.github.io/irsa-tutorials/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.html#vizualize-the-image-with-firefly
+The following tutorial notebooks demonstrates the use of Firefly Python client:
+
+- `Using Firefly visualization tools in Python to vet SEDs <https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/SEDs_in_Firefly.html>`_
+- `Using Firefly visualization tools to understand the light curves of Solar System objects <https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/NEOWISE_light_curve_demo.html>`_
+- `Using Firefly to Explore OpenUniverse2024 Data Preview Simulated Roman and Rubin Images <https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/OpenUniverse2024Preview_Firefly.html>`_
+- `Euclid Q1: PHZ catalogs — Visualize with Firefly section <https://caltech-ipac.github.io/irsa-tutorials/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.html#vizualize-the-image-with-firefly>`_
 
 
 Other Examples

--- a/docs/usage/demo-notebooks.rst
+++ b/docs/usage/demo-notebooks.rst
@@ -1,0 +1,39 @@
+###############
+Demo Notebooks
+###############
+
+
+Reference Guide
+-----------------
+
+For a high-level overview of the Firefly Python client API and important methods, refer to this `reference guide notebook`.
+
+.. _`reference guide notebook`:
+    https://nbviewer.org/github/Caltech-IPAC/firefly_client/tree/master/examples/reference-guide.ipynb.
+
+
+Science Use-cases
+-----------------
+
+IRSA Tutorials is collection of multiple notebooks that demonstrate the use of IRSA data services and tools for science use-cases.
+The following notebook demonstrates the use of Firefly Python Client:
+- https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/SEDs_in_Firefly.html
+- https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/NEOWISE_light_curve_demo.html
+- https://caltech-ipac.github.io/irsa-tutorials/tutorials/firefly/OpenUniverse2024Preview_Firefly.html
+- https://caltech-ipac.github.io/irsa-tutorials/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.html#vizualize-the-image-with-firefly
+
+
+Other Examples
+---------------
+
+For a full list of notebooks/scripts that demonstrate the use of
+Firefly Python client, refer to |nbviewer_examples| (rendered in nbviewer).
+
+.. warning::
+    Several of the notebooks in the examples directory use deprecated API (or discouraged API that is about to be deprecated) and will be updated soon.
+
+
+.. |nbviewer_examples| raw:: html
+
+   <a href="https://nbviewer.org/github/Caltech-IPAC/firefly_client/tree/master/examples/"
+   target="_blank">this examples directory</a>

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -12,15 +12,4 @@ Using firefly_client
    viewing-tables
    charting
    callbacks-extensions
-
-
-Examples
---------
-
-You can find a list of notebooks/scripts that demonstrate the use of
-firefly_client in |nbviewer_examples|. 
-
-.. |nbviewer_examples| raw:: html
-
-   <a href="https://nbviewer.org/github/Caltech-IPAC/firefly_client/tree/master/examples/"
-   target="_blank">this directory (rendered in nbviewer)</a>
+   demo-notebooks

--- a/examples/reference-guide.ipynb
+++ b/examples/reference-guide.ipynb
@@ -1,0 +1,811 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reference Guide to Firefly Python Client API\n",
+    "This notebook aims to give a high-level overview of the Firefly Python client API and important methods to get you started. For **full explanation** of each method and its parameter, check [FireflyClient API reference](https://caltech-ipac.github.io/firefly_client/api/firefly_client.FireflyClient.html).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_client import FireflyClient\n",
+    "\n",
+    "# Following imports are just for example data fetching and processing\n",
+    "from astropy.utils.data import download_file\n",
+    "from astropy.io import fits\n",
+    "import numpy as np\n",
+    "import io"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize Firefly Client\n",
+    "Firefly is a web application (with a URL) that can be controlled from Python with a `FireflyClient` object. \n",
+    "\n",
+    "To indicate which Firefly server to talk to from our Python client, we set the environment variable `FIREFLY_URL`. In this notebook, we use a public Firefly server: the IRSA Viewer (https://irsa.ipac.caltech.edu/irsaviewer). However, you can also run a local Firefly server via a [Firefly Docker image](https://hub.docker.com/r/ipac/firefly) and access it at `http://localhost:8080/firefly`.\n",
+    "\n",
+    "There are two ways to initialize `FireflyClient` from Python, depending on whether you're running the notebook in JupyterLab or not:\n",
+    "\n",
+    "### From Jupyter Lab\n",
+    "Assuming you have `jupyter-firefly-extensions` set up in your environment as explained [here](https://github.com/Caltech-IPAC/jupyter_firefly_extensions/blob/master/README.md), you can use `make_lab_client()` in JupyterLab, which will open the Firefly viewer in a new tab within the Lab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fc = FireflyClient.make_lab_client()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### From Jupyter Notebook (or even a Python shell)\n",
+    "You can use `make_client()` in a Jupyter Notebook (or even a Python shell), which will open the Firefly viewer in a new web browser tab. `make_client()` also allows you to pass the URL directly (other than through environment variable) as the `url` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fc = FireflyClient.make_client() # URL is taken from FIREFLY_URL env variable\n",
+    "\n",
+    "# URL can be defined explicitly as a parameter\n",
+    "fc = FireflyClient.make_client(url=\"https://irsa.ipac.caltech.edu/irsaviewer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## [Optional] Reinitialize Firefly Client\n",
+    "To clean the state of Firefly server (aka remove all displayed components and start fresh), you can reinitialise it. This is specifically helpful if a Python connection with server is already open and re-running `make_lab_client` (or `make_client`) leads to stale state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.reinit_viewer()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show FITS Image in Firefly\n",
+    "\n",
+    "Use the `show_fits_image` method of the FireflyClient object to display a FITS image. It can take a local file path, URL, or a file-like object as input via the `file_input` parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### From a URL\n",
+    "You can specify url of any FITS image. Here we use cutout of a WISE all-sky image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutout_image_url = 'https://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a/149/02206a149-w1-int-1b.fits?center=70,20&size=400pix'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cutout_image_plot_id = 'wise-cutout'\n",
+    "fc.show_fits_image(file_input=cutout_image_url,\n",
+    "                   plot_id=cutout_image_plot_id,\n",
+    "                   title='WISE Cutout')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### From a local file\n",
+    "You can specify path of any local FITS file. Here we download the full WISE all-sky image and use its file path:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/jsinghal/.astropy/cache/download/url/8d0c853f180330d78cea76026057a827/contents'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_image_url = 'http://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p1bm_frm/6a/02206a/149/02206a149-w1-int-1b.fits'\n",
+    "full_image_fpath = download_file(full_image_url, cache=True, timeout=120)\n",
+    "full_image_fpath"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_image_plot_id = 'wise-fullimage'\n",
+    "fc.show_fits_image(file_input=full_image_fpath,\n",
+    "                   plot_id=full_image_plot_id, # using a different plot id to not overwrite previous plot\n",
+    "                   title='WISE Full Image')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### From an in-memory file-like object\n",
+    "You can also use a file-like object (e.g. `BytesIO` stream) instead of a local file path or URL. This is useful when you are working with a FITS file in memory and don't want to write it to disk. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/v9/2dzh8dk57glf4lxq5vv50sdm0005p2/T/ipykernel_23034/1845551643.py:7: RuntimeWarning: invalid value encountered in sqrt\n",
+      "  img_data = np.sqrt(img_data)\n"
+     ]
+    }
+   ],
+   "source": [
+    "processed_fits = io.BytesIO()\n",
+    "\n",
+    "with fits.open(cutout_image_url) as hdul:\n",
+    "    # Do some processing on FITS image data\n",
+    "    img_data = hdul[0].data\n",
+    "    img_data[:10, :] = img_data[-10:, :] = img_data[:, :10] = img_data[:, -10:] = np.nanmax(img_data)\n",
+    "    img_data = np.sqrt(img_data)\n",
+    "\n",
+    "    new_hdu = fits.PrimaryHDU(data=img_data, header=hdul[0].header)\n",
+    "    new_hdu.writeto(processed_fits, overwrite=True)\n",
+    "    processed_fits.seek(0) # to bring reading pointer to the beginning of file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.show_fits_image(file_input=processed_fits,\n",
+    "                   plot_id='wise-processed',\n",
+    "                   title='Processed WISE Cutout')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modify the displayed image(s)\n",
+    "### Panning to a coordinate\n",
+    "To pan the full image to center on a cutout's center 70 +20 EQ-J2000:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.set_pan(plot_id=full_image_plot_id, # note we use the plot id we defined above\n",
+    "           x=70, y=20, coord='j2000')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Zooming\n",
+    "To zoom into the full image by a factor of 2:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.set_zoom(plot_id=full_image_plot_id, factor=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Aligning multiple images\n",
+    "To align both full image and cutout image by WCS and to lock the WCS matching:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.align_images(lock_match=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Changing the color stretch\n",
+    "Set the stretch for the full image based on IRAF zscale interval with a linear algorithm:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True,\n",
+       " 'rv_string': '91,1.000000,91,1.000000,NaN,2.000000,44,25,600,120,0,NaN,1.000000'}"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.set_stretch(plot_id=full_image_plot_id, stype='zscale', algorithm='linear')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show Table/Catalogs in Firefly\n",
+    "\n",
+    "Use the `show_table` method of the FireflyClient object to display a table/catalog. Similar to `show_fits_image`, it can take a local file path, URL, or a file-like object as input via the same `file_input` parameter.\n",
+    "\n",
+    "Here we use a 2MASS catalog (using IRSA VO TAP):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table_url = \"http://irsa.ipac.caltech.edu/TAP/sync?FORMAT=IPAC_TABLE&QUERY=SELECT+*+FROM+fp_psc+WHERE+CONTAINS(POINT('J2000',ra,dec),CIRCLE('J2000',70.0,20.0,0.1))=1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "table_id = '2mass-catalog'\n",
+    "fc.show_table(file_input=table_url, # can also be a local file path or file-like object\n",
+    "              tbl_id=table_id,\n",
+    "              title='2MASS Catalog')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Displaying a catalog table also caused Firefly to overlay the image with markers by default. The markers can be visible on both \"wise-cutout\" and \"wise-fullimage\" since they would include the same field of view. Also we see the active chart and coverage tab as bonus!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modify the displayed table\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sorting by a column\n",
+    "You can sort the table by a column in ascending (ASC) or descending (DESC) order:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.sort_table_column(tbl_id=table_id,\n",
+    "                     column_name='j_m', sort_direction='ASC')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filtering the rows\n",
+    "Filters can be specified as an SQL WHERE clause-like string with column names quoted:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.apply_table_filters(tbl_id=table_id, # note: we use the table id we defined above\n",
+    "                       filters='\"j_m\">15 and \"j_m\"<16 and \"j_cmsig\"<0.06')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To remove the filters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.apply_table_filters(tbl_id=table_id, filters='')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot Chart from the displayed table\n",
+    "We can use the dispalyed table data to plot columns on X and Y axis:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.show_xyplot(tbl_id=table_id, xCol='j_m', yCol='h_m-k_m')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, more generic method show_chart() can be used to create the same plot which accepts a lot of configuration parameters as [Plotly data structure](https://plotly.com/javascript/reference/index/):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trace0 = {'tbl_id': table_id, 'x': \"tables::j_m\", 'y': \"tables::h_m-k_m\", \n",
+    "          'type' : 'scatter', 'mode': 'markers',\n",
+    "          'marker': dict(size=4, color='red', opacity=0.6)}\n",
+    "layout = {'title': '2MASS color-mag',\n",
+    "           'xaxis': dict(title='J'), 'yaxis': dict(title='H - K')}\n",
+    "\n",
+    "status = fc.show_chart(data=[trace0], layout=layout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot Region overlays on the displayed image\n",
+    "\n",
+    "[ds9-style regions](https://ds9.si.edu/doc/ref/region.html) can be overlaid on the image displayed by Firefly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sources_box = \"icrs;box 70d 20d 12' 12' 0d\"\n",
+    "image_regions_id = 'wise-regions'\n",
+    "fc.overlay_region_layer(region_data=sources_box,\n",
+    "                        title='WISE all-sky Annotations', \n",
+    "                        region_layer_id=image_regions_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add region data to an existing region layer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ra, dec = 69.992614, 20.088488\n",
+    "point_source = f'icrs;point {ra}d {dec}d # point=cross 25 text={{Source A}}'\n",
+    "fc.add_region_data(region_data=point_source,\n",
+    "                   region_layer_id=image_regions_id) # note: we use same region_layer_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To remove region layer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fc.delete_region_layer(image_regions_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show HiPS image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hips_url = 'http://alasky.u-strasbg.fr/DSS/DSSColor'\n",
+    "hips_plot_id = 'hips-img-id'\n",
+    "target = '70;20;EQ_J2000'\n",
+    "\n",
+    "fc.show_hips(plot_id=hips_plot_id, \n",
+    "             hips_root_url=hips_url,\n",
+    "             Title='HiPS-DSS', \n",
+    "             WorldPt=target)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show 3-color image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# [W4, W2, W1] from WISE all-sky as [R, G, B] \n",
+    "rgb_urls = ['https://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p3am_cdd/07/0704/0704p196_ab41/0704p196_ab41-w4-int-3.fits',\n",
+    "            'https://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p3am_cdd/07/0704/0704p196_ab41/0704p196_ab41-w2-int-3.fits',\n",
+    "            'https://irsa.ipac.caltech.edu/ibe/data/wise/allsky/4band_p3am_cdd/07/0704/0704p196_ab41/0704p196_ab41-w1-int-3.fits']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "three_color_params = [\n",
+    "    {\n",
+    "        'url': url,\n",
+    "        'Title': \"3 color image\"\n",
+    "    } for url in rgb_urls]\n",
+    "\n",
+    "fc.show_fits_3color(three_color_params=three_color_params,\n",
+    "                    plot_id='3color-img')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Because we added more images, align and lock them by WCS again\n",
+    "fc.align_images(lock_match=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show any data file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Preview metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Directly view data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ffpy",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference-guide.ipynb
+++ b/examples/reference-guide.ipynb
@@ -757,14 +757,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Show any data file"
+    "## Show any data file\n",
+    "To explore any data file you have at hand without delving into image or table specific options, you can use the `show_data` method of the FireflyClient object."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Preview metadata"
+    "### Preview metadata\n",
+    "It's often useful to preview the metadata of a data file you have no information about. `preview_metadata` parameter allows you to do that:"
    ]
   },
   {
@@ -772,7 +774,35 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "some_fpath = '/Users/jsinghal/dev/cm/__test_data/MF.20210502.18830.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fc.show_data(some_fpath, preview_metadata=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This allows you to select which extensions/HDUs to load from a multi-extension FITS file. Same can be done for a VOTable with multiple tables."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -782,9 +812,39 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectrum_file_url = 'http://irsa.ipac.caltech.edu/api/spectrumdm/convert/euclid/q1/SIR/102160339/EUC_SIR_W-COMBSPEC_102160339_2024-11-05T16:26:34.614296Z.fits?dataset_id=euclid_combspec&hdu=1644'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fc.show_data(spectrum_file_url, preview_metadata=False)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "Note that show_data is a recent addition to firefly_client and is still evolving. It doesn't allow as much customization as image/table specific methods yet, but it is a quick way to get a look at your data."
+   ]
   }
  ],
  "metadata": {

--- a/firefly_client/fc_utils.py
+++ b/firefly_client/fc_utils.py
@@ -95,6 +95,7 @@ ACTION_DICT = {
     'ShowHiPS': 'ImagePlotCntlr.PlotHiPS',
     'ShowImageOrHiPS': 'ImagePlotCntlr.plotHiPSOrImage',
     'ImagelineBasedFootprint': 'DrawLayerCntlr.ImageLineBasedFP.imagelineBasedFPCreate',
+    'ShowAnyData': 'app_data.externalUpload',
 
     # actions from jupyter_firefly_extensions
     'StartLabWindow': 'StartLabWindow',

--- a/firefly_client/fc_utils.py
+++ b/firefly_client/fc_utils.py
@@ -66,7 +66,7 @@ def ensure3(val, name):
 
 ACTION_DICT = {
     # actions from Firefly JS
-    'ShowFits': 'ImagePlotCntlr.PlotImage',
+    'ShowImage': 'ImagePlotCntlr.PlotImage',
     'AddExtension': 'ExternalAccessCntlr/extensionAdd',
     'FetchTable': 'table.fetch',
     'ShowTable': 'table.search',

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -730,9 +730,11 @@ class FireflyClient:
         """
         return self.dispatch(ACTION_DICT['ReinitViewer'], {})
 
-    def show_fits(self, file_on_server=None, plot_id=None, viewer_id=None, **additional_params):
+    def show_fits_image(self, file_on_server=None, plot_id=None, viewer_id=None, **additional_params):
         """
-        Show a FITS image.
+        Show a FITS image. If the FITS file has multiple extensions/HDUs (for 
+        images, tables, etc.), all the image extensions are displayed by default
+        within the image plot.
 
         Parameters
         ----------
@@ -785,9 +787,16 @@ class FireflyClient:
         file_on_server and payload['wpRequest'].update({'file': file_on_server})
         additional_params and payload['wpRequest'].update(additional_params)
 
-        r = self.dispatch(ACTION_DICT['ShowFits'], payload)
+        r = self.dispatch(ACTION_DICT['ShowImage'], payload)
         warning and r.update({'warning': warning})
         return r
+    
+    def show_fits(self, *args, **kwargs):
+        """
+        DEPRECATED: Use show_fits_image() instead.
+        """
+        warn("show_fits() is deprecated. Use show_fits_image() instead.")
+        return self.show_fits_image(*args, **kwargs)
 
     def show_fits_3color(self, three_color_params, plot_id=None, viewer_id=None):
         """
@@ -827,7 +836,7 @@ class FireflyClient:
             viewer_id = FireflyClient.PINNED_IMAGE_VIEWER_ID
         payload.update({'viewerId': viewer_id})
 
-        r = self.dispatch(ACTION_DICT['ShowFits'], payload)
+        r = self.dispatch(ACTION_DICT['ShowImage'], payload)
         warning and r.update({'warning': warning})
         return r
 

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -543,8 +543,8 @@ class FireflyClient:
 
         Returns
         -------
-        out : `dict`
-            Status, like {'success': True}.
+        out: `str`
+            Path of file after the upload.
         """
         return self.upload_data(stream, 'FITS')
 
@@ -561,8 +561,8 @@ class FireflyClient:
 
         Returns
         -------
-        out : `dict`
-            Status, like {'success': True}.
+        out: `str`
+            Path of file after the upload.
         """
         return self.upload_data(stream, 'UNKNOWN')
 
@@ -580,8 +580,8 @@ class FireflyClient:
 
         Returns
         -------
-        out : `dict`
-            Status, like {'success': True}.
+        out: `str`
+            Path of file after the upload.
         """
 
         url = self.url_cmd_service + '?cmd=upload&preload='
@@ -640,6 +640,49 @@ class FireflyClient:
         debug('dispatch: type: %s, channel: %s \n%s' % (action_type, channel, dict_to_str(action)))
 
         return self._send_url_as_post(data)
+    
+    def get_payload_from_file(self, file_input):
+        """Get payload for actions dispatched to Firefly server from the file input.
+
+        It does all guesswork to determine file type and uploads it to the server if needed.
+
+        Parameters
+        ----------
+        file_input : `str` or `file-like object`
+            The input file to show. It can be a local file path, a URL to a
+            remote file, name of a file on the server (return value of
+            `upload_file()`), or a file-like object (such as an open IO stream).
+        
+        Returns
+        -------
+        out : `dict` 
+            A dict that can be used as part of payload. The returned dict will 
+            have one of the following keys:
+            - 'fileOnServer': `str` (server file reference for the uploaded file/stream)
+            - 'url': `str` (for a remote file)
+        """
+        if isinstance(file_input, str):
+            if file_input.startswith('${'): # already a server file reference
+                return {'fileOnServer': file_input}
+            elif os.path.isfile(file_input): # local file path
+                return {'fileOnServer': self.upload_file(file_input)}
+            elif re.match(r'^https?://', file_input): # remote file url
+                return {'url': file_input}
+        elif isinstance(file_input, io.IOBase) and hasattr(file_input, 'seek'): # file-like object
+            return {'fileOnServer': self.upload_data(file_input, 'UNKNOWN')}
+        # invalid input
+        raise ValueError('file_input must be a valid file path string or a file-like object')
+    
+    def get_title_from_file(self, file_input):
+        """Get a title from a file input if possible."""
+        if isinstance(file_input, str):
+            if os.path.isfile(file_input):
+                return os.path.basename(file_input)
+            elif re.match(r'^https?://', file_input):
+                url_basename = os.path.basename(file_input.split('?', 1)[0]) # remove query parameters
+                _, ext = os.path.splitext(url_basename)
+                return url_basename if ext else None
+        return None
 
     # -------------------------
     # dispatch actions
@@ -732,24 +775,8 @@ class FireflyClient:
             Status of the request, like {'success': True}.
         """
         return self.dispatch(ACTION_DICT['ReinitViewer'], {})
-    
-    def get_file_payload(self, file_input):
-        # TODO: debug displayName not appearing in some cases
-        if isinstance(file_input, str):
-            if file_input.startswith('$'):
-                return {'fileOnServer': file_input}
-            elif os.path.isfile(file_input):
-                return {'fileOnServer': self.upload_file(file_input),
-                        'displayName': os.path.basename(file_input)}
-            elif re.match(r'^https?://', file_input):
-                return {'url': file_input,
-                        'displayName': os.path.basename(file_input)}
-        elif isinstance(file_input, io.IOBase) and hasattr(file_input, 'seek'): # file-like object
-            return {'fileOnServer': self.upload_data(file_input, 'UNKNOWN')}
-        raise ValueError('file_input must be a valid file path string or a file-like object')
 
-    def show_data(self, file_input, preview_metadata=False,
-                  **data_view_options):
+    def show_data(self, file_input, preview_metadata=False, title=None):
         """
         Show any data file of the type that Firefly supports:
         - Custom catalog or table in IPAC, CSV, TSV, VOTABLE, Parquet, or FITS table format
@@ -762,68 +789,92 @@ class FireflyClient:
         Parameters
         ----------
         file_input : `str` or `file-like object`
-            If `str`, it can be a local file path, a URL to a remote file, or
-            name of a file on the server (return value of `upload_file()`).
-            Else it can be a file stream object (file-like object) opened in Python.
+            The input file to show. It can be a local file path, a URL to a
+            remote file, name of a file on the server (return value of
+            `upload_file()`), or a file-like object (such as an open IO stream).
         preview_metadata : `bool`, optional
             If True, preview the metadata of the file before loading the data.
             This allows you to select FITS extensions, table columns, etc. and 
             then you can click "Load" button in the UI to load your selections.
             Default is False.
-        **data_view_options : optional keyword arguments
-            Additional options for the view of this data file in the UI, such as:
-            **displayName** : `str`, optional
-                A name to display in the UI for the data file loaded.
+        title : `str`, optional
+            Title to display with the data view in the UI. If not provided,
+            will be derived from the file name if possible.
         """
         payload = {
-            **self.get_file_payload(file_input),
+            **self.get_payload_from_file(file_input),
             'immediate': not preview_metadata,
-            **data_view_options # TODO: pass data_view_id -> didn't work
+            'displayName': self.get_title_from_file(file_input) if not title else title,
+            # TODO: support optional keyword arguments like data_view_id, image/table/region options, etc.
+            # **data_view_options
             }
         return self.dispatch(ACTION_DICT['ShowAnyData'], payload)
 
-    def show_fits_image(self, file_on_server=None, plot_id=None, viewer_id=None, **additional_params):
+    def show_fits_image(self, file_input=None, file_on_server=None, url=None, 
+                        plot_id=None, viewer_id=None, **additional_params):
         """
-        Show a FITS image. If the FITS file has multiple extensions/HDUs (for 
+        Show a FITS image. 
+        
+        If the FITS file has multiple extensions/HDUs (for 
         images, tables, etc.), all the image extensions are displayed by default
-        within the image plot.
+        within the image plot. You can use the `multiImageIdx` parameter
+        to display only a particular image extension from the file.
 
         Parameters
         ----------
+        file_input : `str` or `file-like object`, optional
+            The input file to show. It can be a local file path, a URL to a
+            remote file, name of a file on the server (return value of
+            `upload_file()`), or a file-like object (such as an open IO stream).
         file_on_server : `str`, optional
             The is the name of the file on the server.
             If you use `upload_file()`, then it is the return value of the method. Otherwise it is a file that
             Firefly has direct access to.
+
+            .. note:: Ignored if `file_input` is provided, which can automatically
+                      upload a local file and use its name on the server.
+        url : `str`, optional
+            URL of the FITS image file, if it's not a local file you can upload.
+
+            .. note:: Ignored if `file_input` is provided, which can automatically
+                      infer if a URL is passed to it.
         plot_id : `str`, optional
             The ID you assign to the image plot. This is necessary to further control the plot.
         viewer_id : `str`, optional
             The ID you assign to the viewer (or cell) used to contain the image plot. If grid view is used for
             display, the viewer id is the cell id of the cell which contains the image plot.
 
+            .. note:: Not needed in triview mode of Firefly, which is also 
+                      the default view mode.
+
         **additional_params : optional keyword arguments
-            Any valid fits viewer plotting parameter, please see the details in `FITS plotting parameters`_.
+            Any valid fits viewer plotting parameter, please see the details in 
+            `FITS plotting parameters`_ (note that they are case-insensitive).
+            These also allow you to directly show an image retrieved from a 
+            data service rather than from a file input, as explained in `this section`.
 
             .. _`FITS plotting parameters`:
                 https://github.com/Caltech-IPAC/firefly/blob/dev/docs/fits-plotting-parameters.md
+            .. _`this section`:
+                https://github.com/Caltech-IPAC/firefly/blob/dev/docs/fits-plotting-parameters.md#parameters-for-specifying-fits-files-retrieved-from-a-service
 
             More options are shown as below:
 
-            **MultiImageIdx** : `int`, optional
+            **multiImageIdx** : `int`, optional
                 Display only a particular image extension from the file (zero-based index).
-            **Title** : `str`, optional
+            **title** : `str`, optional
                 Title to display with the image.
-            **url** : `str`, optional
-                URL of the fits image file, if it's not a local file you can upload.
 
         Returns
         -------
         out : `dict`
             Status of the request, like {'success': True}.
 
-        .. note:: Either `file_on_server` or the target information set by `additional_params`
-                  is used for image search.
+        .. note:: `file_input`, `url`, `file_on_server`, and service specific `additional_params` are exclusively required.
+            If more than one of these 4 parameters are passed, precedence order is:
+            service specific `additional_params` > (`file_input` > `file_on_server` > `url`).
         """
-
+        # WebPlotRequest parameters
         wp_request = {'plotGroupId': 'groupFromPython',
                       'GroupLocked': False}
         payload = {'wpRequest': wp_request,
@@ -836,7 +887,19 @@ class FireflyClient:
 
         payload.update({'viewerId': viewer_id})
         plot_id and payload['wpRequest'].update({'plotId': plot_id})
+
+        # Handle different params of file input
         file_on_server and payload['wpRequest'].update({'file': file_on_server})
+        url and payload['wpRequest'].update({'url': url})
+        if file_input:
+            file_payload = self.get_payload_from_file(file_input)
+            if 'fileOnServer' in file_payload:
+                # WebPlotRequest uses 'file' as the key for the file on server
+                file_payload['file'] = file_payload.pop('fileOnServer')
+            payload['wpRequest'].update(file_payload) # overrides url or file_on_server if any
+
+        # Add the additional params including the image view related options, and
+        # service specific options (which implicitly overrides the above file params if any, when WebPlotRequest is processed)
         additional_params and payload['wpRequest'].update(additional_params)
 
         r = self.dispatch(ACTION_DICT['ShowImage'], payload)
@@ -892,7 +955,8 @@ class FireflyClient:
         warning and r.update({'warning': warning})
         return r
 
-    def show_table(self, file_on_server=None, url=None, tbl_id=None, title=None, page_size=100, is_catalog=True,
+    def show_table(self, file_input=None, file_on_server=None, url=None, 
+                   tbl_id=None, title=None, page_size=100, is_catalog=True,
                    meta=None, target_search_info=None, options=None, table_index=None,
                    column_spec=None, filters=None, visible=True):
         """
@@ -900,12 +964,22 @@ class FireflyClient:
 
         Parameters
         ----------
+        file_input : `str` or `file-like object`, optional
+            The input file to show. It can be a local file path, a URL to a
+            remote file, name of a file on the server (return value of
+            `upload_file()`), or a file-like object (such as an open IO stream).
         file_on_server : `str`, optional
             The name of the file on the server.
             If you use `upload_file()`, then it is the return value of the method. Otherwise it is a file that
             Firefly has direct access to.
+
+            .. note:: Ignored if `file_input` is provided, which can automatically
+                      upload a local file and use its name on the server.
         url : `str`, optional
             URL of the table file, if it's not a local file you can upload.
+
+            .. note:: Ignored if `file_input` is provided, which can automatically
+                      infer if a URL is passed to it.
         tbl_id : `str`, optional
             A table ID. It will be created automatically if not specified.
         title : `str`, optional
@@ -919,37 +993,37 @@ class FireflyClient:
         target_search_info : `dict`, optional
             The information for target search, it may contain the following fields:
 
-            **catalogProject** : `str`
+            - **catalogProject** : `str`
                 Catalog project, such as *'WISE'*.
-            **catalog** : `str`
+            - **catalog** : `str`
                 Table to be searched, such as *'allwise_p3as_psd'*.
-            **use** : `str`
+            - **use** : `str`
                 Usage of the table search, such as *'catalog_overlay'*.
-            **position** : `str`
+            - **position** : `str`
                 Target position, such as *'10.68479;41.26906;EQ_J2000'*.
-            **SearchMethod** : {'Cone', 'Eliptical', 'Box', 'Polygon', 'Table', 'AllSky'}
+            - **SearchMethod** : {'Cone', 'Eliptical', 'Box', 'Polygon', 'Table', 'AllSky'}
                 Target search method.
-            **radius** : `float`
+            - **radius** : `float`
                 The radius for *'Cone'* or the semi-major axis for *'Eliptical'* search in terms of unit *arcsec*.
-            **posang** : `float`
+            - **posang** : `float`
                 Position angle for *'Eliptical'* search in terms of unit *arcsec*.
-            **ratio** : `float`
+            - **ratio** : `float`
                 Axial ratio for *'Eliptical'* search.
-            **size** : `float`
+            - **size** : `float`
                 Side size for *'Box'* search in terms of unit *arcsec*.
-            **polygon** : `str`
+            - **polygon** : `str`
                 ra/dec of polygon corners, such as *'ra1, dec1, ra2, dec2,... raN, decN'*.
-            **filename** : `str`
+            - **filename** : `str`
                 The name of file on server on multi-objects for *'Table'* search.
 
         options : `dict`, optional
-            Containing parameters for table display, such as,
+            Containing parameters for table display, such as:
 
-            **removable** : `bool`
+            - **removable** : `bool`
                 if table is removable.
-            **showUnits** : `bool`
+            - **showUnits** : `bool`
                 if table shows units for the columns.
-            **showFilters** : `bool`
+            - **showFilters** : `bool`
                 if table shows filter button
         table_index : `int`, optional
             The table to be shown in case `file_on_server` contains multiple tables. It is the extension number for
@@ -971,23 +1045,38 @@ class FireflyClient:
         out : `dict`
             Status of the request, like {'success': True}.
 
-        .. note:: `url`, `file_on_server`, and `target_search_info` are exclusively required.
-            If more than one of these 3 parameters are passed, precedence order is:
-            `url` > `file_on_server` > `target_search_info`
+        .. note:: `file_input`, `url`, `file_on_server`, and `target_search_info` are exclusively required.
+            If more than one of these 4 parameters are passed, precedence order is:
+            (`file_input` > `file_on_server` > `url`) > `target_search_info`
         """
+        has_file_input = bool(file_on_server) or bool(url) or bool(file_input)
 
         if not tbl_id:
             tbl_id = gen_item_id('Table')
         if not title:
-            title = tbl_id if file_on_server or url else target_search_info.get('catalog', tbl_id)
+            if has_file_input:
+                title_from_file = self.get_title_from_file(file_input)
+                title = title_from_file if title_from_file else tbl_id
+            else:
+                title = target_search_info.get('catalog', tbl_id)
 
         meta_info = {'title': title, 'tbl_id': tbl_id}
         meta and meta_info.update(meta)
 
         tbl_req = {'startIdx': 0, 'pageSize': page_size, 'tbl_id': tbl_id}
-        if file_on_server or url:
+        if has_file_input:
             tbl_type = 'table' if not is_catalog else 'catalog'
-            source = url if url else file_on_server
+            
+            # Handle different params of file input
+            source = None
+            if file_input:
+                file_payload = self.get_payload_from_file(file_input)
+                source = file_payload.get('fileOnServer') or file_payload.get('url')
+            elif file_on_server:
+                source = file_on_server
+            elif url:
+                source = url
+
             tbl_req.update({'source': source, 'tblType': tbl_type,
                             'id': 'IpacTableFromSource'})
             table_index and tbl_req.update({'tbl_index': table_index})
@@ -997,6 +1086,8 @@ class FireflyClient:
             tbl_req.update({'id': 'GatorQuery', 'UserTargetWorldPt': target_search_info.get('position')})
             target_search_info.pop('position', None)
             tbl_req.update(target_search_info)
+        else:
+            raise ValueError('Either file_input/file_on_server/url or target_search_info parameter is required.')
 
         tbl_req.update({'META_INFO': meta_info})
         options and tbl_req.update({'options': options})

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -859,7 +859,7 @@ class FireflyClient:
         three_color_params : `list` of `dict` or `dict`
             A list or objects contains image viewer plotting parameters for either all bands or one single band.
             For valid image viewer plotting parameter, please see the details in `FITS plotting parameters`_ or
-            the description of **additional_params** in function `show_fits`.
+            the description of **additional_params** in function `show_fits_image`.
 
         plot_id : `str`, optional
             The ID you assign to the image plot. This is necessary to further control the plot.
@@ -1440,7 +1440,7 @@ class FireflyClient:
             used for display, the viewer id is the cell id of the cell which contains the image plot.
         image_request : `dict`, optional
             Request with fits plotting parameters. For valid fits viewer plotting parameter, please see the
-            the description of `show_fits` or `show_fits_3color`.
+            the description of `show_fits_image` or `show_fits_3color`.
         hips_request : `dict`, optional
             Request with hips plotting parameters. For valid HiPS viewer plotting parameter, please see the
             description of `show_hips`.
@@ -1780,7 +1780,7 @@ class FireflyClient:
         Returns
         -------
         rvstring : `str`
-            RangeValues string that can be passed to the show_fits methods
+            RangeValues string that can be passed to the show_fits_* methods
         """
         return RangeValues.rvstring_from_dict(rvdict)
 


### PR DESCRIPTION
Fixes [FIREFLY-1573](https://jira.ipac.caltech.edu/browse/FIREFLY-1573)

fixes #65, fixes #66 

- Deprecated `show_fits()` and renamed it to `show_fits_image()`
- Created a `show_data(file_input, preview_metadata, ...)` method for any upload
- Made `show_fits_image()`, `show_table()` accept `file_input` parameter which can infer local file path, url to a remote file, in-memory file object, etc. - avoiding 2 step process of uploading the file
- Added a "Reference Guide" notebook (from AAS workshop) that demonstrates the most up-to-date API
- Updated documentation here and there and added several outdated warnings