### PR TITLE
FIREFLY-1948: Make use of results tabs layout control

### DIFF
--- a/examples/filetable.py
+++ b/examples/filetable.py
@@ -33,7 +33,7 @@ def filetable_to_firefly(
         Instance of FireflyClient connected to a Firefly server
 
     topdir: "str"
-        pathname for directory to search
+        pathname for directory to search, must be an absolute path.
 
     pattern: "str"
         filename pattern to search for, e.g. "*.fits"
@@ -159,10 +159,9 @@ def main():
     if printurl:
         input("Press Enter after you have opened the Firefly URL printed above...")
 
-    # TODO: figure out how to activate data products (meta) tab in Bi-View
-    # if "slate" not in html_file:
-    #     fc.change_triview_layout(firefly_client.FireflyClient.BIVIEW_T_IChCov)
-    #     fc.dispatch('layout.updateLayout', {'images':{'selectedTab':'meta'}})
+    if "slate" not in html_file:
+        fc.change_triview_layout(firefly_client.FireflyClient.BIVIEW_T_IChCov)
+        fc.dispatch('layout.updateLayout', {'rightSide': {'selectedTab': 'meta'}})
     r = fc.add_cell(0, 0, 1, 2, "tables", "main")
     fc.show_table(tbl_val, meta=metainfo)
     r = fc.add_cell(0, 1, 1, 2, "tableImageMeta", "image-meta")
@@ -170,4 +169,7 @@ def main():
 
 
 if __name__ == "__main__":
+    # Test example: 
+    # python filetable.py '/Users/jsinghal/dev/cm/__test_data' '*.*' --firefly_url http://localhost:8080/firefly/
+
     main()

--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -1230,6 +1230,7 @@ class FireflyClient:
 
         payload = {'chartId': cid, 'chartType': 'scatter',
                    'groupId': group_id, 'viewerId': group_id,
+                   'activateViewer': True,
                    'params': {'tbl_id': tbl_id, **chart_params}}
 
         r = self.dispatch(ACTION_DICT['ShowXYPlot'], payload)
@@ -1281,6 +1282,7 @@ class FireflyClient:
         payload = {'chartId': cid, 'chartType': 'histogram',
                    'groupId': group_id,
                    'viewerId': group_id,
+                   'activateViewer': True,
                    'params': {'tbl_id': tbl_id, **histogram_params}}
 
         r = self.dispatch(ACTION_DICT['ShowXYPlot'], payload)
@@ -1330,6 +1332,7 @@ class FireflyClient:
         payload = {'chartId': chart_id,
                    'groupId': group_id,
                    'viewerId': group_id,
+                   'activateViewer': True,
                    'chartType': 'plot.ly',
                    'closable': True}
 


### PR DESCRIPTION
Fixes [FIREFLY-1948](https://jira.ipac.caltech.edu/browse/FIREFLY-1948)

Also see Firefly PR: https://github.com/Caltech-IPAC/firefly/pull/1910

## Testing
Install Python package from this build.

- Show chart methods should activate Pinned charts tab by default as soon as chart is created
- The filetable script should have Data Products tab activated in the Bi-view layout of Results.